### PR TITLE
preload ig's

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 - updated CDA core logical model 2.0 and added tests
 - docker multiarchitecture support and ci-build setup [#76](https://github.com/ahdis/matchbox/issues/76)
 - proxy support for downloading packages, thanks @ValentinLorand for your [PR](https://github.com/ahdis/matchbox/pull/74), [#76](https://github.com/ahdis/matchbox/issues/76)
+- matchbox-server: disable caching for specific engines / implementation guides [#77](https://github.com/ahdis/matchbox/issues/77)
 
 2023/02/01 Release 3.1.0
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -35,8 +35,33 @@ Validation for profile http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-pat
 Default validation parameters can be set directly in provided application.yaml
 
 ```yaml
+hapi:
+  fhir:
+    implementationguides:
+      fhir_r4_core:
+        name: hl7.fhir.r4.core
+        version: 4.0.1
+        url: classpath:/hl7.fhir.r4.core.tgz
+      fhir_terminology:
+        name: hl7.terminology
+        version: 5.0.0
+        url: classpath:/hl7.terminology#5.0.0.tgz
+      cda:
+        name: ch.fhir.ig.cda-fhir-maps
+        version: 0.4.0-cibuild
+        url: https://build.fhir.org/ig/hl7ch/cda-fhir-maps/package.tgz
+      chemd:
+        name: ch.fhir.ig.ch-emed
+        version: 3.0.0
 matchbox:
   fhir:
     context:
       txServer: n/a
+      igsPreloaded: ch.fhir.ig.cda-fhir-maps#0.4.0-cibuild, ch.fhir.ig.ch-emed#3.0.0
 ```
+
+| Parameter            | Card  | Description                                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| implementationguides | 0..\* | the Implementation Guide and version which with which matchbox will be configured, you can provide by classpath, file, http address, if none is specified the FHIR package servers will be used (need to be online)                                                                                                                                                                              |
+| txServer             | 0..1  | txServer to use, n/a if none (default)                                                                                                                                                                                                                                                                                                                                                           |
+| igsPreloaded         | 0..\* | For each mentioned ImplemetationGuide (comma seperated) an engine will be created, which will be cached in memory as long the application is running. Other IG's will created on demand and will be cached for an hour for subsequent calls. Tradeoff between memory consumption and first response time (creating of engine might have duration of half a minute). Default no igs are preloaded |

--- a/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProvider.java
@@ -197,7 +197,7 @@ public class ImplementationGuideProvider extends ca.uhn.fhir.jpa.rp.r4.Implement
 
 	public PackageInstallOutcomeJson loadAll(boolean replace) {
 		matchboxEngineSupport.setInitialized(false);
-		log.info("Initializing packages" + VersionUtil.getMemory());
+		log.info("Initializing packages " + VersionUtil.getMemory());
 		PackageInstallOutcomeJson installOutcome = null;
 		if (appProperties.getImplementationGuides() != null) {
 			Map<String, AppProperties.ImplementationGuide> guides = appProperties.getImplementationGuides();
@@ -218,6 +218,10 @@ public class ImplementationGuideProvider extends ca.uhn.fhir.jpa.rp.r4.Implement
 			}
 		}
 		matchboxEngineSupport.setInitialized(true);
+		log.info("Initializing packages finished " + VersionUtil.getMemory());
+		log.info("Creating cached engines during startup  " + VersionUtil.getMemory());
+		matchboxEngineSupport.getMatchboxEngine("default",null, false, false);
+		log.info("Finished engines during startup  " + VersionUtil.getMemory());
 		return installOutcome;
 	}
 

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/CliContext.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/CliContext.java
@@ -143,6 +143,12 @@ public class CliContext {
   @JsonProperty("jurisdiction")
   private String jurisdiction = JurisdictionUtilities.getJurisdictionFromLocale(Locale.getDefault().getCountry());
 
+  private String igsPreloaded[];
+
+  public String[] getIgsPreloaded() {
+    return igsPreloaded;
+  }
+
   @Autowired
   public CliContext(Environment environment) {
     		// get al list of all JsonProperty of cliContext with return values property name and property type
@@ -163,7 +169,9 @@ public class CliContext {
 					log.error("error setting property " + cliContextProperty + " to " + value);
 				}
 			}
-		}  
+		}
+    // get properties array from the environment?
+    this.igsPreloaded = environment.getProperty("matchbox.fhir.context.igsPreloaded", String[].class);
   }
 
   public CliContext(CliContext other) {
@@ -180,6 +188,7 @@ public class CliContext {
 				log.error("error setting property " + field.getName() );
 			} 
 		}
+    this.igsPreloaded = other.igsPreloaded;
   }
 
   @JsonProperty("ig")

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/util/EgineSessionCache.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/util/EgineSessionCache.java
@@ -1,0 +1,89 @@
+/*
+* #%L
+* Matchbox
+* %%
+* Copyright (c) 2023- by ahdis ag. All rights reserved.
+* %%
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*      http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* #L%
+*/
+
+package ch.ahdis.matchbox.util;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.Map;
+
+import org.hl7.fhir.validation.ValidationEngine;
+import org.hl7.fhir.validation.cli.services.SessionCache;
+
+/**
+ * @author Oliver Egger
+ * 
+ *         We want to have a validation engines also that are not timed out as
+ *         in the parent classe.
+ */
+public class EgineSessionCache extends SessionCache {
+
+    private final Map<String, ValidationEngine> cachedSessionsNoTimeout = new java.util.HashMap<String, ValidationEngine>();
+
+    /**
+     * Returns the stored {@link ValidationEngine} associated with the passed in
+     * session id, if one such instance exists.
+     * 
+     * @param sessionId The {@link String} session id.
+     * @return The {@link ValidationEngine} associated with the passed in id, or
+     *         null if none exists.
+     */
+    @Override
+    public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
+        if (cachedSessionsNoTimeout.containsKey(sessionId)) {
+            return cachedSessionsNoTimeout.get(sessionId);
+        }
+        return super.fetchSessionValidatorEngine(sessionId);
+    }
+
+    /**
+     * Returns the set of stored session ids.
+     * 
+     * @return {@link Set} of session ids.
+     */
+    @Override
+    public Set<String> getSessionIds() {
+        Set<String> set = super.getSessionIds();
+        set.addAll(cachedSessionsNoTimeout.keySet());
+        return set;
+    }
+
+    /**
+     * Stores the initialized {@link ValidationEngine} in the cache forever. If a
+     * null key is
+     * passed in, a new key is generated and returned.
+     * 
+     * @param sessionId        The {@link String} key to associate with this stored
+     *                         {@link ValidationEngine}
+     * @param validationEngine The {@link ValidationEngine} instance to cache.
+     * @return The {@link String} id that will be associated with the stored
+     *         {@link ValidationEngine}
+     */
+    public String cacheSessionForEver(String sessionId, ValidationEngine validationEngine) {
+        cachedSessionsNoTimeout.put(sessionId, validationEngine);
+        return sessionId;
+    }
+
+    @Override
+    public boolean sessionExists(String sessionId) {
+        return super.sessionExists(sessionId) || cachedSessionsNoTimeout.containsKey(sessionId);
+    }
+
+}

--- a/matchbox-server/src/test/resources/application-test-cda.yaml
+++ b/matchbox-server/src/test/resources/application-test-cda.yaml
@@ -143,7 +143,11 @@ hapi:
         name: ch.fhir.ig.cda-fhir-maps
         version: 0.4.0-cibuild
         url: https://build.fhir.org/ig/hl7ch/cda-fhir-maps/package.tgz
+      ch-emed:
+        name: ch.fhir.ig.ch-emed
+        version: 3.0.0
 matchbox:
   fhir:
     context:
       txServer: n/a
+      igsPreloaded: ch.fhir.ig.cda-fhir-maps#0.4.0-cibuild

--- a/matchbox-server/validation-ch-samples.http
+++ b/matchbox-server/validation-ch-samples.http
@@ -119,7 +119,7 @@ POST {{host}}/$validate?profile=http://fhir.ch/ig/ch-core/StructureDefinition/ch
 
 
 ### CH-Core Franz Muster )
-POST {{host}}/$validate?profile=http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient HTTP/1.1
+POST {{host}}/$validate?profile=http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient&ig=ch.fhir.ig.ch-core#3.0.0 HTTP/1.1
 
 < ./examples/PatientFranzMuster.xml
 


### PR DESCRIPTION
matchbox-server: disable caching for specific engines / implementation guides [#77](https://github.com/ahdis/matchbox/issues/77)

or each mentioned ImplemetationGuide (comma seperated) an engine will be created, which will be cached in memory as long the application is running. Other IG's will created on demand and will be cached for an hour for subsequent calls. Tradeoff between memory consumption and first response time (creating of engine might have duration of half a minute). Default no igs are preloaded 