### PR TITLE
Some fixes

### DIFF
--- a/.github/workflows/angular_build.yml
+++ b/.github/workflows/angular_build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'matchbox-fronted/**'
 
 jobs:
   build-and-commit:

--- a/.github/workflows/angular_test.yml
+++ b/.github/workflows/angular_test.yml
@@ -1,0 +1,30 @@
+name: Test the Angular GUI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./matchbox-frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          # https://github.com/actions/setup-node
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: matchbox-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test the build
+        run: npm run build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,8 +4,6 @@ name: Java CI with Maven
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "charts/**"
 
 jobs:
   build:

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -138,52 +138,6 @@
             <artifactId>h2</artifactId>
         </dependency>
 
-        <!-- webjars -->
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>bootstrap</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>font-awesome</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bower</groupId>
-            <artifactId>awesome-bootstrap-checkbox</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jstimezonedetect</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>select2</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.webjars</groupId>
-                    <artifactId>jquery</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bower</groupId>
-            <artifactId>jquery</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bower</groupId>
-            <artifactId>moment</artifactId>
-        </dependency>
-
         <!-- The following dependencies are only needed for automated unit tests, you do not neccesarily need them to run the example. -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -30,10 +30,6 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-client</artifactId>
         </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -279,11 +279,6 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- dependencies for test -->
         <dependency>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -132,18 +132,6 @@
             <artifactId>spring-web</artifactId>
         </dependency>
 
-        <!-- You may not need this if you are deploying to an application server which provides database connection pools itself. -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- This example uses H2 embedded database. If you are using another database such as Mysql or Oracle, you may omit the following dependencies and replace them with an appropriate database client dependency for your database platform. -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -472,7 +472,6 @@
                 <dependency>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-web</artifactId>
-                    <version>${spring_boot_version}</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -485,7 +484,6 @@
                 <dependency>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-web</artifactId>
-                    <version>${spring_boot_version}</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,16 @@
                 <version>${spring_boot_version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${spring_boot_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-jetty</artifactId>
+                <version>${spring_boot_version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -353,58 +353,6 @@
                 <version>${spring_version}</version>
             </dependency>
             <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>bootstrap</artifactId>
-                <version>5.1.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-                <version>4.17.47</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>font-awesome</artifactId>
-                <version>5.8.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars.bower</groupId>
-                <artifactId>awesome-bootstrap-checkbox</artifactId>
-                <version>1.0.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>jstimezonedetect</artifactId>
-                <version>1.0.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>select2</artifactId>
-                <version>4.0.13</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.webjars</groupId>
-                        <artifactId>jquery</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars.bower</groupId>
-                <artifactId>jquery</artifactId>
-                <version>3.5.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars.bower</groupId>
-                <artifactId>moment</artifactId>
-                <version>2.27.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>4.1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -327,12 +327,6 @@
                 <version>${jetty_version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <scope>provided</scope>
-                <version>3.1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>8.0.25</version>


### PR DESCRIPTION
- Only run Angular build CI if the project has been modified
- Test the Angular project in PRs
- Remove useless paths-ignore in maven.yml
- Remove some dependencies:
	- the mysql connector: only the h2 and postgres databases are used
	- servlet-api: it is included by other dependencies, v3 was required while spring boot 2.7/tomcat 9 depend on the v4.
	- dbcp2: tomcat uses its own database connection pool
	- webjars: not sure why they were included, the GUI is a self-sufficient Angular build so they should not be needed.

Fixing #85, not fully fixing #88 yet.