### PR TITLE
Upgrade dependencies (latest)

### DIFF
--- a/matchbox-server/src/test/java/ch/ahdis/validation/IgValidateR4TestStandalone.java
+++ b/matchbox-server/src/test/java/ch/ahdis/validation/IgValidateR4TestStandalone.java
@@ -195,10 +195,6 @@ public class IgValidateR4TestStandalone {
     return resources;
   }
 
-	public IgValidateR4TestStandalone(String name, Resource resource) {
-		this(name, resource, GenericFhirClient.testServer);
-	}
-
   public IgValidateR4TestStandalone(String name, Resource resource, String targetServer) {
     super();
     this.resource = resource;

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <fhir.core.version>5.6.116</fhir.core.version>
-        <hapi.fhir.version>6.4.1</hapi.fhir.version>
+        <fhir.core.version>5.6.117</fhir.core.version>
+        <hapi.fhir.version>6.4.4</hapi.fhir.version>
 
         <log4j_to_slf4j_version>2.17.1</log4j_to_slf4j_version>
         <!-- Dependency Versions -->
@@ -91,17 +91,17 @@
         <poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
         <resteasy_version>5.0.2.Final</resteasy_version>
         <ph_schematron_version>5.6.5</ph_schematron_version>
-        <ph_commons_version>9.5.4</ph_commons_version>
+        <ph_commons_version>9.5.5</ph_commons_version>
         <plexus_compiler_api_version>2.9.0</plexus_compiler_api_version>
         <servicemix_saxon_version>9.8.0-15</servicemix_saxon_version>
         <servicemix_xmlresolver_version>1.2_5</servicemix_xmlresolver_version>
         <swagger_version>2.1.12</swagger_version>
         <slf4j_version>1.7.33</slf4j_version>
         <log4j_to_slf4j_version>2.17.1</log4j_to_slf4j_version>
-        <spring_version>5.3.18</spring_version>
+        <spring_version>5.3.27</spring_version>
         <spring_data_version>2.6.1</spring_data_version>
         <spring_batch_version>4.3.3</spring_batch_version>
-        <spring_boot_version>2.7.5</spring_boot_version>
+        <spring_boot_version>2.7.11</spring_boot_version>
         <spring_retry_version>1.2.2.RELEASE</spring_retry_version>
         <stax2_api_version>3.1.4</stax2_api_version>
         <testcontainers_version>1.17.1</testcontainers_version>
@@ -109,7 +109,7 @@
         <woodstox_core_asl_version>4.4.1</woodstox_core_asl_version>
         <jacoco_version>0.8.7</jacoco_version>
         <info_cqframework_version>1.5.1</info_cqframework_version>
-        <lombok_version>1.18.24</lombok_version>
+        <lombok_version>1.18.26</lombok_version>
         <byte_buddy_version>1.10.21</byte_buddy_version>
         <apache_poi_version>4.1.1</apache_poi_version>
     </properties>


### PR DESCRIPTION
Upgrade dependencies:

- HAPI to 6.4.4
- FHIR Core to 5.6.117
- Spring to 5.3.27
- Spring Boot to 2.7.11