### PR TITLE
Load IGs in the main thread, at application start event

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+YYYY/MM/DD Release 3.5.4
+
+- `docker pull europe-west6-docker.pkg.dev/ahdis-ch/ahdis/matchbox:v3.5.4`
+- The application now stops if it fails to load an IG, instead of continuing running without an engine [#171](https://github.com/ahdis/matchbox/issues/171)
+- GUI: improved the validation interface [#177](https://github.com/ahdis/matchbox/issues/177)
+
 2024/01/05 Release 3.5.3
 
 - `docker pull europe-west6-docker.pkg.dev/ahdis-ch/ahdis/matchbox:v3.5.3`

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter;
 
+import ch.ahdis.matchbox.spring.MatchboxEventListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.SpringApplication;
@@ -24,7 +25,8 @@ import ch.ahdis.matchbox.MatchboxJpaConfig;
 @Import({
 	MdmConfig.class,
 	MatchboxJpaConfig.class,
-	FhirServerConfigR4.class})
+	FhirServerConfigR4.class,
+	MatchboxEventListener.class})
 public class Application extends SpringBootServletInitializer {
 
   public static void main(String[] args) {

--- a/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProviderR4.java
+++ b/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProviderR4.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import ca.uhn.fhir.jpa.rp.r4.ImplementationGuideResourceProvider;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.ImplementationGuide;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -69,8 +70,8 @@ import ch.ahdis.matchbox.util.MatchboxPackageInstallerImpl;
  *
  */
 @DisallowConcurrentExecution
-public class ImplementationGuideProviderR4 extends ca.uhn.fhir.jpa.rp.r4.ImplementationGuideResourceProvider
-		implements Job, ApplicationContextAware {
+public class ImplementationGuideProviderR4 extends ImplementationGuideResourceProvider
+		implements ApplicationContextAware, MatchboxImplementationGuideProvider {
 
 	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ImplementationGuideProviderR4.class);
 
@@ -262,16 +263,6 @@ public class ImplementationGuideProviderR4 extends ca.uhn.fhir.jpa.rp.r4.Impleme
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-	}
-
-	@Override
-	public void execute(JobExecutionContext context) throws JobExecutionException {
-		try {
-			context.getScheduler().unscheduleJob(context.getTrigger().getKey());
-			this.loadAll(false);
-		} catch (SchedulerException e) {
-			e.printStackTrace();
-		}
 	}
 
 	@Override

--- a/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProviderR5.java
+++ b/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/ImplementationGuideProviderR5.java
@@ -43,7 +43,7 @@ import java.util.*;
  */
 @DisallowConcurrentExecution
 public class ImplementationGuideProviderR5 extends ImplementationGuideResourceProvider
-		implements Job, ApplicationContextAware {
+		implements ApplicationContextAware, MatchboxImplementationGuideProvider {
 
 	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ImplementationGuideProviderR5.class);
 
@@ -208,16 +208,6 @@ public class ImplementationGuideProviderR5 extends ImplementationGuideResourcePr
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-	}
-
-	@Override
-	public void execute(JobExecutionContext context) throws JobExecutionException {
-		try {
-			context.getScheduler().unscheduleJob(context.getTrigger().getKey());
-			this.loadAll(false);
-		} catch (SchedulerException e) {
-			e.printStackTrace();
-		}
 	}
 
 	@Override

--- a/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/MatchboxImplementationGuideProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/fhir/hapi/jpa/validation/MatchboxImplementationGuideProvider.java
@@ -1,0 +1,13 @@
+package ch.ahdis.fhir.hapi.jpa.validation;
+
+import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
+
+/**
+ * Additional interface for Matchbox's ImplementationGuideResourceProviders.
+ *
+ * @author Quentin Ligier
+ **/
+public interface MatchboxImplementationGuideProvider {
+
+	PackageInstallOutcomeJson loadAll(boolean replace);
+}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/MatchboxJpaConfig.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/MatchboxJpaConfig.java
@@ -178,14 +178,9 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 											  structureMapTransformProvider, codeSystemCodeValidationProvider,
 											  valueSetCodeValidationProvider);
 
-
-		ScheduledJobDefinition jobDefinition = new ScheduledJobDefinition();
-		jobDefinition.setId(this.getClass().getName());
-
 		switch (this.myFhirContext.getVersion().getVersion()) {
 			case R4 -> {
 				fhirServer.registerProviders(this.implementationGuideResourceProviderR4);
-				jobDefinition.setJobClass(ImplementationGuideProviderR4.class);
 
 				if (appProperties.getOnly_install_packages() != null && appProperties.getOnly_install_packages()
 					&& appProperties.getImplementationGuides() != null) {
@@ -196,7 +191,6 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 			}
 			case R5 -> {
 				fhirServer.registerProviders(this.implementationGuideResourceProviderR5);
-				jobDefinition.setJobClass(ImplementationGuideProviderR5.class);
 
 				if (appProperties.getOnly_install_packages() != null && appProperties.getOnly_install_packages()
 					&& appProperties.getImplementationGuides() != null) {
@@ -210,8 +204,6 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 		}
 
 		fhirServer.setServerConformanceProvider(new MatchboxCapabilityStatementProvider(this.myFhirContext,fhirServer, structureDefinitionProvider, getCliContext()));
-
-		mySvc.scheduleLocalJob(DateUtils.MILLIS_PER_MINUTE, jobDefinition);
 
 		return fhirServer;
 	}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/spring/MatchboxEventListener.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/spring/MatchboxEventListener.java
@@ -1,0 +1,37 @@
+package ch.ahdis.matchbox.spring;
+
+import ch.ahdis.fhir.hapi.jpa.validation.MatchboxImplementationGuideProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Spring event listener for Matchbox.
+ *
+ * @author Quentin Ligier
+ **/
+@Component
+public class MatchboxEventListener implements ApplicationListener<ApplicationReadyEvent> {
+	private static final Logger log = LoggerFactory.getLogger(MatchboxEventListener.class);
+
+	private final MatchboxImplementationGuideProvider igProvider;
+
+	public MatchboxEventListener(final MatchboxImplementationGuideProvider igProvider) {
+		this.igProvider = requireNonNull(igProvider);
+	}
+
+	/**
+	 * Handle an application event.
+	 *
+	 * @param ignored the event to respond to
+	 */
+	@Override
+	public void onApplicationEvent(final ApplicationReadyEvent ignored) {
+		log.info("Loading all ImplementationGuides");
+		this.igProvider.loadAll(false);
+	}
+}


### PR DESCRIPTION
Fixes #171.
It allows stopping the application if there is an error loading an IG, instead of continuing without an engine.