### PR TITLE
Save installed StructureDefinitions in database

### DIFF
--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -192,11 +192,13 @@ import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.util.IMetaTagSorter;
 import ca.uhn.fhir.util.MetaTagSorterAlphabetical;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
+import ca.uhn.fhir.jpa.model.entity.MbInstalledStructureDefinitionEntity;
+import ca.uhn.fhir.jpa.dao.data.MbInstalledStructureDefinitionRepository;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.common.hapi.validation.support.UnknownCodeSystemWarningValidationSupport;
-import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
 import org.hl7.fhir.utilities.graphql.IGraphQLStorageServices;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -216,7 +218,7 @@ import java.util.Date;
 @Configuration
 // repositoryFactoryBeanClass: EnversRevisionRepositoryFactoryBean is needed primarily for unit testing
 @EnableJpaRepositories(
-		basePackages = "ca.uhn.fhir.jpa.dao.data",
+		basePackages = {"ca.uhn.fhir.jpa.dao.data",},
 		repositoryFactoryBeanClass = EnversRevisionRepositoryFactoryBean.class)
 @Import({
 	BeanPostProcessorConfig.class,

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/MbInstalledStructureDefinitionRepository.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/MbInstalledStructureDefinitionRepository.java
@@ -1,0 +1,14 @@
+package ca.uhn.fhir.jpa.dao.data;
+
+import ca.uhn.fhir.jpa.model.entity.MbInstalledStructureDefinitionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface MbInstalledStructureDefinitionRepository
+	extends JpaRepository<MbInstalledStructureDefinitionEntity, Long> {
+  
+  @Query("SELECT e FROM MbInstalledStructureDefinitionEntity e WHERE e.isValidatable = TRUE")
+  List<MbInstalledStructureDefinitionEntity> findAllValidatable();
+}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/MbInstalledStructureDefinitionEntity.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/MbInstalledStructureDefinitionEntity.java
@@ -1,0 +1,197 @@
+package ca.uhn.fhir.jpa.model.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * This table contains the list of StructureDefinitions currently installed in Matchbox.
+ */
+@Entity()
+@Table(
+	name = "MB_INSTALLED_STRUCT_DEF",
+	indexes = {
+		@Index(name = "IDX_IS_VALIDATABLE", columnList = "IS_VALIDATABLE"),
+	})
+public class MbInstalledStructureDefinitionEntity implements Serializable {
+
+	/**
+	 * A primary key for the table.
+	 */
+	@Id
+	@SequenceGenerator(name = "SEQ_MB_INSTSTRUCTDEF", sequenceName = "SEQ_MB_INSTSTRUCTDEF")
+	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_MB_INSTSTRUCTDEF")
+	@Column(name = "PID")
+	private Long id;
+
+	/**
+	 * StructureDefinition.url
+	 */
+	@Column(name = "CANONICAL_URL", length = 200, nullable = false)
+	private String canonicalUrl;
+
+	/**
+	 * StructureDefinition.title or StructureDefinition.name
+	 */
+	@Column(name = "TITLE", length = 200, nullable = false)
+	private String title;
+
+	/**
+	 * ImplementationGuide.packageId
+	 */
+	@Column(name = "PACKAGE_ID", length = 200, nullable = false)
+	private String packageId;
+
+	/**
+	 * ImplementationGuide.version
+	 */
+	@Column(name = "PACKAGE_VERSION", length = 200, nullable = false)
+	private String packageVersion;
+
+	/**
+	 * StructureDefinition.type
+	 */
+	@Column(name = "TYPE", length = 100, nullable = false)
+	private String type;
+
+	/**
+	 * StructureDefinition.kind: primitive-type | complex-type | resource | logical
+	 */
+	@Column(name = "KIND", length = 20, nullable = false)
+	private String kind;
+
+	/**
+	 * Whether the package version is the current one (i.e. the most recent one) or not.
+	 */
+	@Column(name = "IS_CURRENT", nullable = false)
+	private Boolean isCurrent;
+
+	/**
+	 * Whether that StructureDefinition can be used for validation or not.
+	 */
+	@Column(name = "IS_VALIDATABLE", nullable = false)
+	private Boolean isValidatable;
+
+  /**
+   * We keep a link to the original entity and cascade changes.
+   * Like that, if it gets removed, this entity will also be removed.
+   */
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "NPM_PACKAGE_VER_RES_ID", referencedColumnName = "PID")
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private NpmPackageVersionResourceEntity npmPackageVersionResourceEntity;
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	public String getCanonicalUrl() {
+		return this.canonicalUrl;
+	}
+
+	public void setCanonicalUrl(final String canonicalUrl) {
+		this.canonicalUrl = canonicalUrl;
+	}
+
+	public String getTitle() {
+		return this.title;
+	}
+
+	public void setTitle(final String title) {
+		this.title = title;
+	}
+
+	public String getPackageId() {
+		return this.packageId;
+	}
+
+	public void setPackageId(final String packageId) {
+		this.packageId = packageId;
+	}
+
+	public String getPackageVersion() {
+		return this.packageVersion;
+	}
+
+	public void setPackageVersion(final String packageVersion) {
+		this.packageVersion = packageVersion;
+	}
+
+	public String getType() {
+		return this.type;
+	}
+
+	public void setType(final String type) {
+		this.type = type;
+	}
+
+	public String getKind() {
+		return this.kind;
+	}
+
+	public void setKind(final String kind) {
+		this.kind = kind;
+	}
+
+	public Boolean isCurrent() {
+		return this.isCurrent;
+	}
+
+	public void setCurrent(final Boolean current) {
+		isCurrent = current;
+	}
+
+	public Boolean isValidatable() {
+		return this.isValidatable;
+	}
+
+	public void setValidatable(final Boolean validatable) {
+		isValidatable = validatable;
+	}
+  
+  public void setNpmPackageVersionResourceEntity(final NpmPackageVersionResourceEntity npmPackageVersionResourceEntity) {
+    this.npmPackageVersionResourceEntity = npmPackageVersionResourceEntity;
+  }
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) return true;
+		if (!(o instanceof final MbInstalledStructureDefinitionEntity that)) return false;
+		return id.equals(that.id)
+			&& canonicalUrl.equals(that.canonicalUrl)
+			&& title.equals(that.title)
+			&& packageId.equals(that.packageId)
+			&& packageVersion.equals(that.packageVersion)
+			&& type.equals(that.type)
+			&& kind.equals(that.kind)
+			&& isCurrent.equals(that.isCurrent)
+			&& isValidatable.equals(that.isValidatable);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, canonicalUrl, title, packageId, packageVersion, type, kind, isCurrent, isValidatable);
+	}
+
+	@Override
+	public String toString() {
+		return "MbInstalledStructureDefinitionEntity{" +
+			"id=" + id +
+			", canonicalUrl='" + canonicalUrl + '\'' +
+			", title='" + title + '\'' +
+			", packageId='" + packageId + '\'' +
+			", packageVersion='" + packageVersion + '\'' +
+			", type='" + type + '\'' +
+			", kind='" + kind + '\'' +
+			", isCurrent=" + isCurrent +
+			", isValidatable=" + isValidatable +
+			'}';
+	}
+}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -138,6 +138,9 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 
 	@Autowired(required = false) // It is possible that some implementers will not create such a bean.
 	private IBinaryStorageSvc myBinaryStorageSvc;
+  
+  @Autowired
+  private MatchboxJpaPackageCache matchboxJpaPackageCache;
 
 	@Override
 	public void addPackageServer(@Nonnull PackageServer thePackageServer) {
@@ -416,7 +419,7 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 						resourceEntity.setCanonicalVersion(version);
 					}
           // PATCH MATCHBOX: the next line is our customization hook: https://github.com/ahdis/matchbox/issues/341
-          MatchboxJpaPackageCache.customizeNpmPackageVersionResourceEntity(resourceEntity, resource);
+          matchboxJpaPackageCache.interceptEntityBeforeSaving(resourceEntity, resource);
 					myPackageVersionResourceDao.save(resourceEntity);
 
 					String resType = packageContext.getResourceType(resource);

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -15,6 +15,7 @@ import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
 

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
@@ -9,6 +9,8 @@ import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.jpa.config.JpaConfig;
 import ch.ahdis.matchbox.CliContext;
 import ch.ahdis.matchbox.interceptors.*;
+import ch.ahdis.matchbox.packages.MatchboxJpaPackageCache;
+import ca.uhn.fhir.jpa.dao.data.MbInstalledStructureDefinitionRepository;
 import ch.ahdis.matchbox.mappinglanguage.StructureMapListProvider;
 import ch.ahdis.matchbox.packages.*;
 import ch.ahdis.matchbox.providers.*;
@@ -66,7 +68,6 @@ import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.common.StarterJpaConfig;
-import ca.uhn.fhir.jpa.validation.JpaValidationSupportChain;
 import ca.uhn.fhir.mdm.provider.MdmProviderLoader;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
@@ -166,6 +167,9 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 	@Autowired
 	private ValueSetCodeValidationProvider valueSetCodeValidationProvider;
 
+	@Autowired
+	private MbInstalledStructureDefinitionRepository installedStructureDefinitionRepository;
+
 	// removed GraphQlProvider
 	// removed IVAldiationSupport
 	
@@ -246,7 +250,11 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 																      "implementationGuideResourceProvider");
 		}
 
-		fhirServer.setServerConformanceProvider(new MatchboxCapabilityStatementProvider(this.myFhirContext,fhirServer, structureDefinitionProvider, getCliContext()));
+		fhirServer.setServerConformanceProvider(new MatchboxCapabilityStatementProvider(this.myFhirContext,
+																												  fhirServer,
+																												  this.structureDefinitionProvider,
+																												  getCliContext(),
+																												  this.installedStructureDefinitionRepository));
 
 		return fhirServer;
 	}
@@ -420,5 +428,10 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 	@Bean
 	public InstallNpmPackageProvider installNpmPackageOperationProvider(final MatchboxPackageInstallerImpl packageInstallerSvc) {
 		return new InstallNpmPackageProvider(packageInstallerSvc);
+	}
+
+	@Bean
+	public MatchboxJpaPackageCache matchboxJpaPackageCache(final MbInstalledStructureDefinitionRepository installedStructureDefinitionRepository) {
+		return new MatchboxJpaPackageCache(installedStructureDefinitionRepository);
 	}
 }

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/MatchboxJpaPackageCache.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/MatchboxJpaPackageCache.java
@@ -73,6 +73,12 @@ public class MatchboxJpaPackageCache {
 															final org.hl7.fhir.r4.model.@Nullable StructureDefinition sdR4,
 															final org.hl7.fhir.r4b.model.@Nullable StructureDefinition sdR4b,
 															final org.hl7.fhir.r5.model.@Nullable StructureDefinition sdR5) {
+		// 1. Modify the original entity
+		//    We update the canonical version to the package version for StructureDefinitions
+		//    https://github.com/ahdis/matchbox/issues/225
+		npmPackageVersionResourceEntity.setCanonicalVersion(npmPackageVersionResourceEntity.getPackageVersion().getVersionId());
+
+		// 2. Extract interesting info
 		final var terser = new FhirTerserWrapper(sdR4, sdR4b, sdR5);
 		var title = terser.getSinglePrimitiveValueOrNull("title");
 		if (title == null) {
@@ -85,6 +91,7 @@ public class MatchboxJpaPackageCache {
 			&& !"logical".equals(kind)
 			&& !"Extension".equals(type);
 
+		// 3. Create our own entity for the StructureDefinition
 		final var entity = new MbInstalledStructureDefinitionEntity();
 		entity.setCanonicalUrl(npmPackageVersionResourceEntity.getCanonicalUrl());
 		entity.setTitle(title);
@@ -95,7 +102,6 @@ public class MatchboxJpaPackageCache {
 		entity.setCurrent(npmPackageVersionResourceEntity.getPackageVersion().isCurrentVersion());
 		entity.setValidatable(isValidatable);
 		entity.setNpmPackageVersionResourceEntity(npmPackageVersionResourceEntity);
-
 		this.installedStructureDefinitionRepository.save(entity);
 	}
 

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/MatchboxJpaPackageCache.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/MatchboxJpaPackageCache.java
@@ -1,90 +1,102 @@
 package ch.ahdis.matchbox.packages;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.dao.data.MbInstalledStructureDefinitionRepository;
+import ca.uhn.fhir.jpa.model.entity.MbInstalledStructureDefinitionEntity;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionResourceEntity;
 import ca.uhn.fhir.util.FhirTerser;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 /**
- * matchbox
+ * A service to help Matchbox customizing the JPA
  *
  * @author Quentin Ligier
  * @see <a href="https://github.com/ahdis/matchbox/issues/341">The NpmPackageVersionResourceEntity update is costly</a>
  **/
+@Service
 public class MatchboxJpaPackageCache {
-	private static final Logger ourLog = LoggerFactory.getLogger(MatchboxJpaPackageCache.class);
 
-	public static final String SD_EXTENSION_TITLE_PREFIX = "[Extension] ";
-	public static final String SD_PRIMITIVE_DT_TITLE_PREFIX = "[Primitive Datatype] ";
-	public static final String SD_COMPLEX_DT_TITLE_PREFIX = "[Complex Datatype] ";
-	public static final String SD_LOGICAL_TITLE_PREFIX = "[Logical] ";
+	private final MbInstalledStructureDefinitionRepository installedStructureDefinitionRepository;
 
-	/**
-	 * This class is not instantiable.
-	 */
-	private MatchboxJpaPackageCache() {
+	public MatchboxJpaPackageCache(final MbInstalledStructureDefinitionRepository installedStructureDefinitionRepository) {
+		this.installedStructureDefinitionRepository = installedStructureDefinitionRepository;
 	}
 
 	/**
-	 * This is Matchbox's hook to customize the {@link NpmPackageVersionResourceEntity}s being generated when loading a
-	 * package.
+	 * This is Matchbox's hook to intercept the {@link NpmPackageVersionResourceEntity}s being generated when loading a
+	 * package right before it gets saved in the database.
 	 * <p>
 	 * This will check the resource type and delegate to the appropriate method to customize the entity.
 	 */
-	public static void customizeNpmPackageVersionResourceEntity(final NpmPackageVersionResourceEntity entity,
-																					final IBaseResource res) {
+	public void interceptEntityBeforeSaving(final NpmPackageVersionResourceEntity entity,
+														 final IBaseResource res) {
 		switch (res) {
-			case org.hl7.fhir.r4.model.StructureDefinition sdR4 -> customizeStructureDefinition(entity, sdR4, null, null);
+			case org.hl7.fhir.r4.model.StructureDefinition sdR4 ->
+				this.interceptStructureDefinition(entity, sdR4, null, null);
 			case org.hl7.fhir.r4b.model.StructureDefinition sdR4b ->
-				customizeStructureDefinition(entity, null, sdR4b, null);
-			case org.hl7.fhir.r5.model.StructureDefinition sdR5 -> customizeStructureDefinition(entity, null, null, sdR5);
-			case org.hl7.fhir.r4.model.StructureMap smR4 -> customizeStructureMap(entity, smR4, null, null);
-			case org.hl7.fhir.r4b.model.StructureMap smR4b -> customizeStructureMap(entity, null, smR4b, null);
-			case org.hl7.fhir.r5.model.StructureMap smR5 -> customizeStructureMap(entity, null, null, smR5);
+				this.interceptStructureDefinition(entity, null, sdR4b, null);
+			case org.hl7.fhir.r5.model.StructureDefinition sdR5 ->
+				this.interceptStructureDefinition(entity, null, null, sdR5);
+			case org.hl7.fhir.r4.model.StructureMap smR4 -> this.updateStructureMap(entity, smR4, null, null);
+			case org.hl7.fhir.r4b.model.StructureMap smR4b -> this.updateStructureMap(entity, null, smR4b, null);
+			case org.hl7.fhir.r5.model.StructureMap smR5 -> this.updateStructureMap(entity, null, null, smR5);
+			default -> { /* do nothing */ }
+		}
+	}
+	/**
+	 * This is Matchbox's hook to intercept the {@link NpmPackageVersionResourceEntity}s being generated when loading a
+	 * package right after it gets saved in the database.
+	 * <p>
+	 * This will check the resource type and delegate to the appropriate method to customize the entity.
+	 */
+	public void interceptEntityAfterSaving(final NpmPackageVersionResourceEntity entity,
+														 final IBaseResource res) {
+		switch (res) {
+			case org.hl7.fhir.r4.model.StructureDefinition sdR4 ->
+				this.interceptStructureDefinition(entity, sdR4, null, null);
+			case org.hl7.fhir.r4b.model.StructureDefinition sdR4b ->
+				this.interceptStructureDefinition(entity, null, sdR4b, null);
+			case org.hl7.fhir.r5.model.StructureDefinition sdR5 ->
+				this.interceptStructureDefinition(entity, null, null, sdR5);
 			default -> { /* do nothing */ }
 		}
 	}
 
 	/**
-	 * Updates the NpmPackageVersionResourceEntity of a StructureDefinition:
-	 * <ol>
-	 *    <li>entity.myFilename now contains the StructureDefinition.title or StructureDefinition.name</li>
-	 *    <li>entity.myCanonicalVersion now contains the StructureDefinition package version</li>
-	 * </ol>
+	 * Intercept a StructureDefinition before it gets saved in the database. Create our
+	 * MbInstalledStructureDefinitionEntity to store it in an optimized way.
 	 */
-	private static void customizeStructureDefinition(final NpmPackageVersionResourceEntity npmPackageVersionResourceEntity,
-																	 final org.hl7.fhir.r4.model.@Nullable StructureDefinition sdR4,
-																	 final org.hl7.fhir.r4b.model.@Nullable StructureDefinition sdR4b,
-																	 final org.hl7.fhir.r5.model.@Nullable StructureDefinition sdR5) {
-		// we update the canonical version to the package version for StructureDefinitions
-		// https://github.com/ahdis/matchbox/issues/225
-		npmPackageVersionResourceEntity.setCanonicalVersion(npmPackageVersionResourceEntity.getPackageVersion().getVersionId());
-
+	private void interceptStructureDefinition(final NpmPackageVersionResourceEntity npmPackageVersionResourceEntity,
+															final org.hl7.fhir.r4.model.@Nullable StructureDefinition sdR4,
+															final org.hl7.fhir.r4b.model.@Nullable StructureDefinition sdR4b,
+															final org.hl7.fhir.r5.model.@Nullable StructureDefinition sdR5) {
 		final var terser = new FhirTerserWrapper(sdR4, sdR4b, sdR5);
-
-		final var type = terser.getSinglePrimitiveValueOrNull("type");
-		final var kind = terser.getSinglePrimitiveValueOrNull("kind");
-
 		var title = terser.getSinglePrimitiveValueOrNull("title");
 		if (title == null) {
 			title = terser.getSinglePrimitiveValueOrNull("name");
 		}
-		if ("primitive-type".equals(kind)) {
-			title = SD_PRIMITIVE_DT_TITLE_PREFIX + title;
-		} else if ("complex-type".equals(kind)) {
-			title = SD_COMPLEX_DT_TITLE_PREFIX + title;
-		} else if ("logical".equals(kind)) {
-			title = SD_LOGICAL_TITLE_PREFIX + title;
-		} else if ("Extension".equals(type)) {
-			title = SD_EXTENSION_TITLE_PREFIX + title;
-		}
+		final var type = terser.getSinglePrimitiveValueOrNull("type");
+		final var kind = terser.getSinglePrimitiveValueOrNull("kind");
+		final var isValidatable = !"primitive-type".equals(kind)
+			&& !"complex-type".equals(kind)
+			&& !"logical".equals(kind)
+			&& !"Extension".equals(type);
 
-		// Change the filename for the StructureDefinition title
-		npmPackageVersionResourceEntity.setFilename(title);
+		final var entity = new MbInstalledStructureDefinitionEntity();
+		entity.setCanonicalUrl(npmPackageVersionResourceEntity.getCanonicalUrl());
+		entity.setTitle(title);
+		entity.setPackageId(npmPackageVersionResourceEntity.getPackageVersion().getPackageId());
+		entity.setPackageVersion(npmPackageVersionResourceEntity.getPackageVersion().getVersionId());
+		entity.setType(type);
+		entity.setKind(kind);
+		entity.setCurrent(npmPackageVersionResourceEntity.getPackageVersion().isCurrentVersion());
+		entity.setValidatable(isValidatable);
+		entity.setNpmPackageVersionResourceEntity(npmPackageVersionResourceEntity);
+
+		this.installedStructureDefinitionRepository.save(entity);
 	}
 
 	/**
@@ -93,26 +105,14 @@ public class MatchboxJpaPackageCache {
 	 *    <li>entity.myFilename now contains the StructureMap.title or StructureMap.name</li>
 	 * </ol>
 	 */
-	private static void customizeStructureMap(final NpmPackageVersionResourceEntity npmPackageVersionResourceEntity,
-															final org.hl7.fhir.r4.model.@Nullable StructureMap smR4,
-															final org.hl7.fhir.r4b.model.@Nullable StructureMap smR4b,
-															final org.hl7.fhir.r5.model.@Nullable StructureMap smR5) {
+	private void updateStructureMap(final NpmPackageVersionResourceEntity npmPackageVersionResourceEntity,
+											  final org.hl7.fhir.r4.model.@Nullable StructureMap smR4,
+											  final org.hl7.fhir.r4b.model.@Nullable StructureMap smR4b,
+											  final org.hl7.fhir.r5.model.@Nullable StructureMap smR5) {
 		final var terser = new FhirTerserWrapper(smR4, smR4b, smR5);
 
 		// Change the filename for the StructureDefinition title
 		npmPackageVersionResourceEntity.setFilename(terser.getSinglePrimitiveValueOrNull("title"));
-	}
-
-	/**
-	 * Checks if a StructureDefinition is validatable, i.e. if it is returned in the list of profiles supported
-	 * by the server in the $validate OperationDefinition and in the Gazelle Webservice.
-	 */
-	public static boolean structureDefinitionIsValidatable(final String title) {
-		// All those prefixes are added when loading the IGs, so we can filter out the profiles
-		return !title.startsWith(SD_EXTENSION_TITLE_PREFIX)
-			&& !title.startsWith(SD_PRIMITIVE_DT_TITLE_PREFIX)
-			&& !title.startsWith(SD_COMPLEX_DT_TITLE_PREFIX)
-			&& !title.startsWith(SD_LOGICAL_TITLE_PREFIX);
 	}
 
 	// A small wrapper around FhirTerser to handle the different FHIR versions of a resource

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
@@ -294,7 +294,7 @@ public class MatchboxEngineSupport {
 				this.configureValidationEngine(mainEngine, cliContextMain);
 			} else if (cliContextMain.getFhirVersion().equals("4.3.0")) {
 				log.debug("Preconfigure FHIR R4B");
-			    mainEngine = new MatchboxEngineBuilder().withXVersion(cliContextMain.getXVersion()).getEngineR4B();
+			   mainEngine = new MatchboxEngineBuilder().withXVersion(cliContextMain.getXVersion()).getEngineR4B();
 				mainEngine.setIgLoader(new IgLoaderFromJpaPackageCache(mainEngine.getPcm(),
 				mainEngine.getContext(),
 				mainEngine.getVersion(),
@@ -307,7 +307,7 @@ public class MatchboxEngineSupport {
 				this.configureValidationEngine(mainEngine, cliContextMain);
 			} else if (cliContextMain.getFhirVersion().equals("5.0.0")) {
 				log.debug("Preconfigure FHIR R5");
-			    mainEngine = new MatchboxEngineBuilder().withXVersion(cliContextMain.getXVersion()).getEngineR5();
+				mainEngine = new MatchboxEngineBuilder().withXVersion(cliContextMain.getXVersion()).getEngineR5();
 				mainEngine.setIgLoader(new IgLoaderFromJpaPackageCache(mainEngine.getPcm(),
 				mainEngine.getContext(),
 				mainEngine.getVersion(),

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -195,8 +195,7 @@ public class ValidationProvider {
 		}
 		if (engine == null) {
 			return this.getOoForError(
-				"Matchbox engine for profile '%s' could not be created, check the installed IGs".formatted(
-					profile));
+				"Matchbox engine for profile '%s' could not be created, check the installed IGs".formatted(profile));
 		}
 		int versionSeparator = profile.lastIndexOf('|');
 		if (versionSeparator != -1) {

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -55,7 +55,6 @@ import org.hl7.fhir.r5.utils.EOperationOutcome;
 import org.hl7.fhir.r5.model.UriType;
 import org.hl7.fhir.r5.utils.OperationOutcomeUtilities;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
-import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/matchbox-server/src/test/java/ch/ahdis/matchbox/gazelle/AbstractGazelleTest.java
+++ b/matchbox-server/src/test/java/ch/ahdis/matchbox/gazelle/AbstractGazelleTest.java
@@ -20,6 +20,9 @@ public abstract class AbstractGazelleTest {
 	}
 
 	public static String getMetadata(final ValidationReport report, final String metadataName) {
+		if (report.getAdditionalMetadata() == null) {
+			return null;
+		}
 		for (final Metadata metadata : report.getAdditionalMetadata()) {
 			if (metadataName.equals(metadata.getName())) {
 				return metadata.getValue();


### PR DESCRIPTION
This makes it much faster to list validatable StructureDefinitions in the GUI and the Gazelle webservice.

It works when installing an IG (hooked to the creation of the `NpmPackageVersionResourceEntity`) and we removing one (it's linked to the `NpmPackageVersionResourceEntity` and the SQL server will cascade the DELETE).
What doesn't work yet is the update when the IG is updated (i.e. the isCurrent flag will change for existing resources).

It probably doesn't work well with an existing database, but having our own SQL migration on top of the HAPI one is quite some work. Do we have any usecase where the database should really be persisted?

~~I'm unsure if we should differentiate between the IG version and the StructureDefinition version.~~ Already discussed in #225, we have to use the IG version

We could also only store validatable StructureDefinitions, that would make it a bit faster. We currently don't need to list non-validatable SDs.

Do we need other info in here?

Not ready to merge.