### PR TITLE
add fml debug and fix cors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2025/05/11 Release 4.0.4
+
+- integrate with https://fhirpath-lab.com/FhirPath [#390](https://github.com/ahdis/matchbox/issues/390) thx to @brianpos
+
 2025/05/09 Release 4.0.3
 
 - matchbox validation: fix ai analysis of xml resources [#378](https://github.com/ahdis/matchbox/issues/378)

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
@@ -549,7 +549,7 @@ public class MatchboxEngine extends ValidationEngine {
 	 * @param inputJson  if input is in json (or xml)
 	 * @param mapUri     map to use for transformation
 	 * @param outputJson if output is formatted as json (or xml)
-	 * @param traceToParameter if the transformation debug log should be traced to a parameter	 * @return transformed input as string
+	 * @return transformed input as string
 	 * @throws FHIRException FHIR Exception
 	 * @throws IOException   IO Exception
 	 */

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/mappinglanguage/TransformSupportServices.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/mappinglanguage/TransformSupportServices.java
@@ -28,11 +28,15 @@ import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.Parameters;
+import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.utils.structuremap.ITransformerServices;
 import org.hl7.fhir.utilities.Utilities;
 
 public class TransformSupportServices implements ITransformerServices {
+
+  private Parameters.ParametersParameterComponent traceToParameter;
 
   private List<Base> outputs;
   private IWorkerContext context;
@@ -42,6 +46,7 @@ public class TransformSupportServices implements ITransformerServices {
     this.context = worker;
     this.outputs = outputs;
   }
+
 
   // matchbox patch https://github.com/ahdis/matchbox/issues/264
   @Override
@@ -56,6 +61,10 @@ public class TransformSupportServices implements ITransformerServices {
       throw new FHIRException("Unable to create type "+name);
     } 
     return Manager.build(context, sd, profileUtilities);
+  }
+
+  public void setTraceToParameter(Parameters.ParametersParameterComponent traceToParameter) {
+    this.traceToParameter = traceToParameter;
   }
 
   @Override
@@ -93,7 +102,13 @@ public class TransformSupportServices implements ITransformerServices {
 
   @Override
   public void log(String message) {
-    log.info(message);
-  }
-
+     if (traceToParameter != null) {
+        Parameters.ParametersParameterComponent traceValue = traceToParameter.addPart();
+        traceValue.setName("debug");
+        traceValue.setValue(new StringType(message));
+      } else {
+        log.info(message);
+      }
+    }
+    
 }

--- a/matchbox-server/fml.http
+++ b/matchbox-server/fml.http
@@ -1,4 +1,4 @@
-@host = http://localhost:8080/matchboxv3/fhir
+@host = http://localhost:8080/matchbox/fhir
 #@host = https://test.ahdis.ch/matchbox/fhir
 ### @host = https://test.ahdis.ch/matchboxv3/fhir
 
@@ -38,10 +38,6 @@ group item(source src, target tgt: Patient) {
 }
 
 ### Convert Textual representation of a FHIR Mapping Language to StructureMap resource
-GET {{host}}/StructureMap/qr2patgender HTTP/1.1
-Accept: application/fhir+json
-
-### Convert Textual representation of a FHIR Mapping Language to StructureMap resource
 GET {{host}}/StructureMap?url=http://ahdis.ch/matchbox/fml/qr2patgender HTTP/1.1
 Accept: application/fhir+json
 
@@ -51,14 +47,6 @@ Accept: application/fhir+json
 Content-Type: text/fhir-mapping
 
 < ./matchbox-engine/src/test/resources/mapping-language/whereclause.map
-
-### Verify that StructureMap is created
-### transform the provided questionnaire response to patient resource with using above created StructureMap
-POST {{host}}/StructureMap/$transform?source=http://ahdis.ch/matchbox/fml/whereclause
-Accept: application/fhir+json
-Content-Type: application/fhir+json
-
-< ./matchbox-engine/src/test/resources/mapping-language/capabilitystatement-example.json
 
 ### transform the provided questionnaire response to patient resource with using above created StructureMap
 POST {{host}}/StructureMap/$transform?source=http://ahdis.ch/matchbox/fml/qr2patgender
@@ -90,7 +78,7 @@ Content-Type: application/fhir+json
 }
 
 ### test transform with provided models (Brian's Fhirpath Lab extension)
-POST {{host}}/StructureMap/$transform
+POST {{host}}/StructureMap/$transform?debug=true
 Accept: application/fhir+xml
 Content-Type: application/fhir+json
 

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/annotations/OnCorsPresent.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/annotations/OnCorsPresent.java
@@ -1,0 +1,20 @@
+package ca.uhn.fhir.jpa.starter.annotations;
+
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class OnCorsPresent implements Condition {
+	@Override
+	public boolean matches(ConditionContext conditionContext, AnnotatedTypeMetadata metadata) {
+
+		AppProperties config = Binder.get(conditionContext.getEnvironment())
+				.bind("hapi.fhir", AppProperties.class)
+				.orElse(null);
+		if (config == null) return false;
+		if (config.getCors() == null) return false;
+		return true;
+	}
+}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -231,7 +231,7 @@ public class StarterJpaConfig {
 
 
 	@Bean
-	@ConditionalOnProperty(prefix = "hapi.fhir", name = "cors")
+	@ConditionalOnProperty(prefix = "hapi.fhir.cors", name = "enabled", havingValue = "true")
 	public CorsInterceptor corsInterceptor(AppProperties appProperties) {
 		// Define your CORS configuration. This is an example
 		// showing a typical setup. You should customize this

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.HttpHeaders;
@@ -62,6 +63,7 @@ import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.jpa.search.IStaleSearchDeletingSvc;
 import ca.uhn.fhir.jpa.search.StaleSearchDeletingSvcImpl;
 import ca.uhn.fhir.jpa.starter.AppProperties;
+import ca.uhn.fhir.jpa.starter.annotations.OnCorsPresent;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
 import ca.uhn.fhir.jpa.util.ResourceCountCache;
 import ca.uhn.fhir.mdm.dao.IMdmLinkDao;
@@ -229,9 +231,8 @@ public class StarterJpaConfig {
 		return new MdmLinkDaoJpaImpl();
 	}
 
-
 	@Bean
-	@ConditionalOnProperty(prefix = "hapi.fhir.cors", name = "enabled", havingValue = "true")
+	@Conditional(OnCorsPresent.class)
 	public CorsInterceptor corsInterceptor(AppProperties appProperties) {
 		// Define your CORS configuration. This is an example
 		// showing a typical setup. You should customize this

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/mappinglanguage/StructureMapTransformProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/mappinglanguage/StructureMapTransformProvider.java
@@ -101,6 +101,7 @@ public class StructureMapTransformProvider extends StructureMapResourceProvider 
 		final String body = new String(theServletRequest.getInputStream().readAllBytes()).trim();
 		@Nullable String resource = null;
 		
+
 		EncodingEnum encoding = EncodingEnum.forContentType(theServletRequest.getContentType());
 		if (encoding == null) {
 			encoding = EncodingEnum.detectEncoding(body);
@@ -212,16 +213,23 @@ public class StructureMapTransformProvider extends StructureMapResourceProvider 
 			final var responseContentType = this.parseRequestedResponseType(theServletRequest);
 			theServletResponse.setContentType(responseContentType);
 
+			final var resultParameters = new Parameters();
+			var debugParameter = theServletRequest.getParameter("debug");
+			Parameters.ParametersParameterComponent traceToParameter = null;
+			if ("true".equalsIgnoreCase(debugParameter)) {
+				traceToParameter = resultParameters.addParameter();
+				traceToParameter.setName("trace");
+			}
+
 			final var transformed = matchboxEngine.transform(resource,
 																			 encoding == EncodingEnum.JSON,
 																			 map.getUrl(),
-																			 responseContentType.contains("json"));
+																			 responseContentType.contains("json"), 
+																			 traceToParameter);
 
 			// if the debug=true flag is on the input, instead wrap this output in a Parameters resource
 			// and return it
-			var debugParameter = theServletRequest.getParameter("debug");
 			if ("true".equalsIgnoreCase(debugParameter)) {
-				final var resultParameters = new Parameters();
 				// var outcome = parameters.addParameter();
 				// outcome.setName("outcome");
 				resultParameters.addParameter("result", new StringType(transformed));

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/mappinglanguage/StructureMapTransformProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/mappinglanguage/StructureMapTransformProvider.java
@@ -219,8 +219,8 @@ public class StructureMapTransformProvider extends StructureMapResourceProvider 
 
 			// if the debug=true flag is on the input, instead wrap this output in a Parameters resource
 			// and return it
-			var debugParemeters = theServletRequest.getParameterValues("debug");
-			if (debugParemeters != null && debugParemeters.length > 0) {
+			var debugParameter = theServletRequest.getParameter("debug");
+			if ("true".equalsIgnoreCase(debugParameter)) {
 				final var resultParameters = new Parameters();
 				// var outcome = parameters.addParameter();
 				// outcome.setName("outcome");

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/questionnaire/QuestionnaireResponseExtractProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/questionnaire/QuestionnaireResponseExtractProvider.java
@@ -95,7 +95,7 @@ public class QuestionnaireResponseExtractProvider {
 
 		final var objectConverter = new ObjectConverter(matchboxEngine.getContext());
 		final var questionnaireResponseElement = objectConverter.convert(parsedRequest.questionnaireResponse());
-		final Element result = matchboxEngine.transform(questionnaireResponseElement, mapUrl, null);
+		final Element result = matchboxEngine.transform(questionnaireResponseElement, mapUrl, null, null);
 
 		httpWrapper.writeResponse(objectConverter.convert(result));
 	}

--- a/matchbox-server/src/main/resources/application.yaml
+++ b/matchbox-server/src/main/resources/application.yaml
@@ -44,7 +44,6 @@ management:
 hapi:
   fhir:
     cors:
-      enabled: true
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
       allowed_origin:

--- a/matchbox-server/src/main/resources/application.yaml
+++ b/matchbox-server/src/main/resources/application.yaml
@@ -44,6 +44,7 @@ management:
 hapi:
   fhir:
     cors:
+      enabled: true
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
       allowed_origin:

--- a/matchbox-server/with-eu/application.yaml
+++ b/matchbox-server/with-eu/application.yaml
@@ -1,0 +1,31 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /matchboxv3
+hapi:
+  fhir:
+    server_address: http://localhost:8080/matchboxv3/fhir
+    implementationguides:
+      fhir_r4_core:
+        name: hl7.fhir.r4.core
+        version: 4.0.1
+        url: classpath:/hl7.fhir.r4.core.tgz
+      fhir_terminology:
+        name: hl7.terminology.r4
+        version: 6.2.0
+        url: classpath:/hl7.terminology.r4#6.2.0.tgz
+      fhir_extensions:
+        name: hl7.fhir.uv.extensions
+        version: 1.0.0
+        url: classpath:/hl7.fhir.uv.extensions#1.0.0.tgz
+      ch-emed:
+        name: ch.fhir.ig.ch-vacd
+        version: 3.0.0 
+matchbox:
+  fhir:
+    context:
+#      txServer: http://tx.fhir.org
+      txServer: http://localhost:${server.port}/matchboxv3/fhir
+      suppressWarnInfo:
+        hl7.fhir.r4.core#4.0.1:
+          - "Constraint failed: dom-6:"


### PR DESCRIPTION
to integrate with #390

## Summary by Sourcery

Introduce a debug mode for StructureMap transformations, improve CORS configuration handling, and integrate with an external FhirPath service, with corresponding documentation updates.

New Features:
- Add debug mode to StructureMap transform endpoint to return output wrapped in a Parameters resource when debug flag is set.

Bug Fixes:
- Fix CORS configuration to only enable CorsInterceptor when CORS settings are present.

Enhancements:
- Integrate with external FhirPath service as referenced in issue #390.

Documentation:
- Update changelog to document new release and integration with FhirPath.