### PR TITLE
suppressErrors #405

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -107,6 +107,15 @@
     },
     {
       "type": "java",
+      "name": "Launch Matchbox-Server (gazelle)",
+      "request": "launch",
+      "mainClass": "ca.uhn.fhir.jpa.starter.Application",
+      "projectName": "matchbox-server",
+      "vmArgs": "-Dspring.config.additional-location=file:with-gazelle/application.yaml",
+      "cwd": "${workspaceFolder}/matchbox-server"
+    },
+    {
+      "type": "java",
       "name": "Launch Matchbox-Server (one engine (dev))",
       "request": "launch",
       "mainClass": "ca.uhn.fhir.jpa.starter.Application",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+2025/06/22 Release 4.0.8
+- suppressErrors not taken into account on gazelle interface [#405](https://github.com/ahdis/matchbox/issues/405)
+
 2025/06/18 Release 4.0.7
 - fix security issues
 

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
@@ -656,22 +656,31 @@ public class MatchboxEngineSupport {
 			// Otherwise, only ignore the warnings that are defined for the IGs that have been loaded in the engine
 			// Note: we remove the hash in the package, because the hash is also removed when reading the YAML
 			//       configuration file.
-			if (!apiDefinedWarnInfos) {
-				validator.getContext().getLoadedPackages().stream()
-					.map(pkg -> pkg.replace("#", ""))
-					.forEach(ig -> {
+			validator.getContext().getLoadedPackages().stream()
+				.map(pkg -> pkg.replace("#", ""))
+				.forEach(ig -> {
+					if (!apiDefinedWarnInfos) {
 						suppressedWarnings.getOrDefault(ig, Collections.emptyList())
 							.forEach(pattern -> this.addSuppressedWarnInfoToEngine(pattern, validator));
-					});
-			}
-			if (!apiDefinedErrors) {
-				validator.getContext().getLoadedPackages().stream().filter(pkg -> pkg.contains("#"))
-					.map(pkg -> pkg.replace("#", ""))
-					.forEach(ig -> {
+						}
+					if (!apiDefinedErrors) {
 						suppressedError.getOrDefault(ig, Collections.emptyList())
 							.forEach(pattern -> this.addSuppressedErrorToEngine(pattern, validator));
-					});
-			}
+					}
+			});
+			validator.getContext().getLoadedPackages().stream().filter(pkg -> pkg.contains("#"))
+				.map(pkg -> pkg.substring(0, pkg.indexOf("#")))
+				.map(pkg -> pkg.replace("#", ""))
+				.forEach(ig -> {
+					if (!apiDefinedWarnInfos) {
+						suppressedWarnings.getOrDefault(ig, Collections.emptyList())
+							.forEach(pattern -> this.addSuppressedWarnInfoToEngine(pattern, validator));
+					}
+					if (!apiDefinedErrors) {
+						suppressedError.getOrDefault(ig, Collections.emptyList())
+							.forEach(pattern -> this.addSuppressedErrorToEngine(pattern, validator));
+					}
+				});
 		}
 	}
 

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
@@ -316,6 +316,7 @@ public class MatchboxEngineSupport {
 					throw new IgLoadException("Failed to load R5 specials", e);
 				}
 				log.debug("Load R5 Specials types");
+				cliContextMain.setIg(this.getFhirCorePackage(cliContextMain));
 				this.configureValidationEngine(mainEngine, cliContextMain);
 			} else if (this.serverFhirVersion == FhirVersionEnum.R4B) {
 				log.debug("Preconfigure FHIR R4B");
@@ -329,6 +330,7 @@ public class MatchboxEngineSupport {
 				this.myDaoRegistry,
 				this.myBinaryStorageSvc,
 				this.myTxManager));
+				cliContextMain.setIg(this.getFhirCorePackage(cliContextMain));
 				this.configureValidationEngine(mainEngine, cliContextMain);
 			} else if (this.serverFhirVersion == FhirVersionEnum.R5) {
 				log.debug("Preconfigure FHIR R5");
@@ -342,11 +344,11 @@ public class MatchboxEngineSupport {
 				this.myDaoRegistry,
 				this.myBinaryStorageSvc,
 				this.myTxManager));
+				cliContextMain.setIg(this.getFhirCorePackage(cliContextMain));
 				this.configureValidationEngine(mainEngine, cliContextMain);
 			} else {
 				throw new MatchboxUnsupportedFhirVersionException("getMatchboxEngineNotSynchronized", this.serverFhirVersion);
 			}
-			cliContextMain.setIg(this.getFhirCorePackage(cliContextMain));
 
 			log.info("Cached default engine forever {} with parameters {}",
 						(cliContextMain.getIg() != null ? "for " + cliContextMain.getIg() : ""),
@@ -660,16 +662,12 @@ public class MatchboxEngineSupport {
 					.forEach(ig -> {
 						suppressedWarnings.getOrDefault(ig, Collections.emptyList())
 							.forEach(pattern -> this.addSuppressedWarnInfoToEngine(pattern, validator));
-						suppressedError.getOrDefault(ig, Collections.emptyList())
-							.forEach(pattern -> this.addSuppressedErrorToEngine(pattern, validator));
 					});
 			}
 			if (!apiDefinedErrors) {
 				validator.getContext().getLoadedPackages().stream().filter(pkg -> pkg.contains("#"))
-					.map(pkg -> pkg.substring(0, pkg.indexOf("#")))
+					.map(pkg -> pkg.replace("#", ""))
 					.forEach(ig -> {
-						suppressedWarnings.getOrDefault(ig, Collections.emptyList())
-							.forEach(pattern -> this.addSuppressedWarnInfoToEngine(pattern, validator));
 						suppressedError.getOrDefault(ig, Collections.emptyList())
 							.forEach(pattern -> this.addSuppressedErrorToEngine(pattern, validator));
 					});

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/gazelle/GazelleValidationWs.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/gazelle/GazelleValidationWs.java
@@ -14,6 +14,8 @@ import ch.ahdis.matchbox.validation.gazelle.models.metadata.Interface;
 import ch.ahdis.matchbox.validation.gazelle.models.metadata.RestBinding;
 import ch.ahdis.matchbox.validation.gazelle.models.metadata.Service;
 import ch.ahdis.matchbox.validation.gazelle.models.validation.*;
+
+import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.slf4j.Logger;
@@ -184,6 +186,12 @@ public class GazelleValidationWs {
 		for (final var pkg : engine.getContext().getLoadedPackages()) {
 			report.addAdditionalMetadata(new Metadata().setName("package").setValue(pkg));
 		}
+		for (final String suppressedWarning : engine.getSuppressedWarnInfoPatterns()) {
+			report.addAdditionalMetadata(new Metadata().setName("suppressedWarning").setValue(suppressedWarning));
+		}		
+		for (final String suppressedError : engine.getSuppressedErrors()) {
+			report.addAdditionalMetadata(new Metadata().setName("suppressedError").setValue(suppressedError));
+		}		
 		report.addAdditionalMetadata(new Metadata().setName("profile").setValue(structDef.getUrl()));
 		report.addAdditionalMetadata(new Metadata().setName("profileVersion").setValue(structDef.getVersion()));
 		report.addAdditionalMetadata(new Metadata().setName("profileDate").setValue(structDef.getDateElement().getValueAsString()));
@@ -194,11 +202,13 @@ public class GazelleValidationWs {
 			final var metadata = new Metadata();
 			metadata.setName(field.getName());
 			try {
-				metadata.setValue(String.valueOf(field.get(cliContext)));
+				if (field.get(cliContext)!=null) {
+					metadata.setValue(String.valueOf(field.get(cliContext)));
+					report.addAdditionalMetadata(metadata);
+				}
 			} catch (final IllegalAccessException exception) {
 				continue;
 			}
-			report.addAdditionalMetadata(metadata);
 		}
 
 		// Response: add the validation items (requests) to the response

--- a/matchbox-server/src/test/java/ch/ahdis/matchbox/gazelle/GazelleApiR4Test.java
+++ b/matchbox-server/src/test/java/ch/ahdis/matchbox/gazelle/GazelleApiR4Test.java
@@ -5,7 +5,6 @@ import ch.ahdis.matchbox.validation.gazelle.models.validation.SeverityLevel;
 import ch.ahdis.matchbox.validation.gazelle.models.validation.ValidationReport;
 import ch.ahdis.matchbox.validation.gazelle.models.validation.ValidationTestResult;
 import ch.ahdis.matchbox.test.CompareUtil;
-import org.apache.jena.base.Sys;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -23,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Quentin Ligier
  **/
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = { Application.class })
 @ActiveProfiles("test-r4")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -46,13 +45,13 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	@Test
 	void validatePatientRawR4() throws Exception {
 		final String patient = """
-			<Patient xmlns="http://hl7.org/fhir">
-				<id value="example"/>
-				<text>
-					<status value="generated"/>
-					<div xmlns="http://www.w3.org/1999/xhtml">42 </div>
-				</text>
-			</Patient>""";
+				<Patient xmlns="http://hl7.org/fhir">
+					<id value="example"/>
+					<text>
+						<status value="generated"/>
+						<div xmlns="http://www.w3.org/1999/xhtml">42 </div>
+					</text>
+				</Patient>""";
 
 		ValidationReport report = this.client.validate(patient, "http://hl7.org/fhir/StructureDefinition/Patient");
 		assertEquals(0, countValidationFailures(report));
@@ -61,10 +60,11 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 		assertTrue(report.getReports().getFirst().getName().contains("first"));
 		assertEquals(1, report.getReports().getFirst().getAssertionReports().size());
 		assertEquals(ValidationTestResult.PASSED,
-						 report.getReports().getFirst().getAssertionReports().getFirst().getResult());
+				report.getReports().getFirst().getAssertionReports().getFirst().getResult());
 		assertEquals(SeverityLevel.INFO,
-						 report.getReports().getFirst().getAssertionReports().getFirst().getSeverity());
-		// TODO: why no "first" in the report? No link between the validation item and the assertion report?
+				report.getReports().getFirst().getAssertionReports().getFirst().getSeverity());
+		// TODO: why no "first" in the report? No link between the validation item and
+		// the assertion report?
 
 		report = this.client.validate(patient, "http://hl7.org/fhir/StructureDefinition/Bundle");
 		assertEquals(1, countValidationFailures(report));
@@ -74,13 +74,13 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	@Test
 	void testSameSessionIdsForSameIg() throws Exception {
 		final String patient = """
-			<Patient xmlns="http://hl7.org/fhir">
-				<id value="example"/>
-				<text>
-					<status value="generated"/>
-					<div xmlns="http://www.w3.org/1999/xhtml">42 </div>
-				</text>
-			</Patient>""";
+				<Patient xmlns="http://hl7.org/fhir">
+					<id value="example"/>
+					<text>
+						<status value="generated"/>
+						<div xmlns="http://www.w3.org/1999/xhtml">42 </div>
+					</text>
+				</Patient>""";
 
 		ValidationReport report = this.client.validate(patient, "http://hl7.org/fhir/StructureDefinition/Patient");
 		final String sessionId1 = getSessionId(report);
@@ -94,12 +94,12 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	@Test
 	void verifyIgVersioningGazelle() throws Exception {
 		final String resource = """
-			<Practitioner xmlns="http://hl7.org/fhir">
-				<identifier>
-					<system value="urn:oid:2.51.1.3"/>
-					<value value="7610000050719"/>
-				</identifier>
-			</Practitioner>""";
+				<Practitioner xmlns="http://hl7.org/fhir">
+					<identifier>
+						<system value="urn:oid:2.51.1.3"/>
+						<value value="7610000050719"/>
+					</identifier>
+				</Practitioner>""";
 
 		String profileMatchbox = "http://matchbox.health/ig/test/r4/StructureDefinition/practitioner-identifier-required";
 
@@ -116,7 +116,8 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 		assertEquals("matchbox.health.test.ig.r4#0.2.0", getIg(report));
 		assertEquals(sessionIdFirst, sessionIdThird);
 
-		// validate with the profile and the ig version, has an internal business version 9.9.9
+		// validate with the profile and the ig version, has an internal business
+		// version 9.9.9
 		profileMatchbox = "http://matchbox.health/ig/test/r4/StructureDefinition/practitioner-identifier-version-different-then-ig";
 		report = this.client.validate(resource, profileMatchbox);
 		String sessionIdForth = getSessionId(report);
@@ -135,7 +136,7 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	// https://gazelle.ihe.net/jira/browse/EHS-431
 	void validateEhs431() throws Exception {
 		ValidationReport report = this.client.validate(getContent("ehs-431.json"),
-																	  "http://hl7.org/fhir/StructureDefinition/Bundle");
+				"http://hl7.org/fhir/StructureDefinition/Bundle");
 		assertEquals(1, countValidationFailures(report));
 	}
 
@@ -143,7 +144,7 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	// https://gazelle.ihe.net/jira/browse/EHS-419
 	void validateEhs419() throws Exception {
 		ValidationReport report = this.client.validate(getContent("ehs-419.json"),
-																	  "http://hl7.org/fhir/StructureDefinition/Patient");
+				"http://hl7.org/fhir/StructureDefinition/Patient");
 		assertEquals(0, countValidationFailures(report));
 	}
 
@@ -151,8 +152,64 @@ public class GazelleApiR4Test extends AbstractGazelleTest {
 	// https://gazelle.ihe.net/jira/browse/EHS-831
 	void validateEhs831() throws Exception {
 		final ValidationReport report = this.client.validate(getContent("ehs-831.json"),
-																			  "http://hl7.org/fhir/StructureDefinition/Parameters");
+				"http://hl7.org/fhir/StructureDefinition/Parameters");
 		assertEquals(ValidationTestResult.PASSED, report.getOverallResult());
 		assertEquals(0, countValidationFailures(report));
 	}
+
+	@Test
+	void checkSuppressError() throws Exception {
+		final String patient = "<RelatedPerson xmlns=\"http://hl7.org/fhir\">\n" + //
+				"  <extension url=\"http://hl7.org/fhir/StructureDefinition/patient-citizenship\">\n" + //
+				"    <extension url=\"code\">\n" + //
+				"      <valueCodeableConcept>\n" + //
+				"        <coding>\n" + //
+				"          <system value=\"urn:iso:std:iso:3166\"/>\n" + //
+				"          <code value=\"CH\"/>\n" + //
+				"          <display value=\"Switzerland\"/>\n" + //
+				"        </coding>\n" + //
+				"      </valueCodeableConcept>\n" + //
+				"    </extension>\n" + //
+				"  </extension>\n" + //
+				"  <patient>\n" + //
+				"    <display value=\"none\"/>\n" + //
+				"  </patient>\n" + //
+				"</RelatedPerson>";
+
+		ValidationReport report = this.client.validate(patient,
+				"http://hl7.org/fhir/StructureDefinition/RelatedPerson");
+		assertEquals(0, countValidationFailures(report));
+		assertEquals(ValidationTestResult.PASSED, report.getOverallResult());
+		assertEquals("first", report.getValidationItems().getFirst().getItemId());
+		assertTrue(report.getReports().getFirst().getName().contains("first"));
+		assertEquals(1, report.getReports().getFirst().getAssertionReports().size());
+	}
+
+	@Test
+	void validateIgnoreErrorMatchboxTest() throws Exception {
+		String practitioner = "<Practitioner xmlns=\"http://hl7.org/fhir\">\n" + //
+				"    <extension url=\"http://hl7.org/fhir/StructureDefinition/unknown\">\n" + //
+				"        <valueCodeableConcept>\n" + //
+				"            <coding>\n" + //
+				"                <system value=\"urn:iso:std:iso:3166\" />\n" + //
+				"                <code value=\"CH\" />\n" + //
+				"                <display value=\"Switzerland\" />\n" + //
+				"            </coding>\n" + //
+				"        </valueCodeableConcept>\n" + //
+				"    </extension>\n" + //
+				"    <identifier>\n" + //
+				"        <system value=\"urn:oid:2.51.1.3\" />\n" + //
+				"        <value value=\"7610000050719\" />\n" + //
+				"    </identifier>\n" + //
+				"</Practitioner>";
+
+		ValidationReport report = this.client.validate(practitioner,
+				"http://matchbox.health/ig/test/r4/StructureDefinition/practitioner-identifier-required");
+		assertEquals(0, countValidationFailures(report));
+		assertEquals(ValidationTestResult.PASSED, report.getOverallResult());
+		assertEquals("first", report.getValidationItems().getFirst().getItemId());
+		assertTrue(report.getReports().getFirst().getName().contains("first"));
+		assertEquals(1, report.getReports().getFirst().getAssertionReports().size());
+	}
+
 }

--- a/matchbox-server/src/test/java/ch/ahdis/matchbox/test/MatchboxApiR4Test.java
+++ b/matchbox-server/src/test/java/ch/ahdis/matchbox/test/MatchboxApiR4Test.java
@@ -285,8 +285,31 @@ class MatchboxApiR4Test {
 		IBaseOperationOutcome operationOutcome = this.validationClient.validate(patient,
 																										"http://hl7.org/fhir/StructureDefinition/RelatedPerson");
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
+	}
 
+	@Test
+	void validateIgnoreErrorMatchboxTest() throws Exception {
+		String practitioner = "<Practitioner xmlns=\"http://hl7.org/fhir\">\n" + //
+						"    <extension url=\"http://hl7.org/fhir/StructureDefinition/unknown\">\n" + //
+						"        <valueCodeableConcept>\n" + //
+						"            <coding>\n" + //
+						"                <system value=\"urn:iso:std:iso:3166\" />\n" + //
+						"                <code value=\"CH\" />\n" + //
+						"                <display value=\"Switzerland\" />\n" + //
+						"            </coding>\n" + //
+						"        </valueCodeableConcept>\n" + //
+						"    </extension>\n" + //
+						"    <identifier>\n" + //
+						"        <system value=\"urn:oid:2.51.1.3\" />\n" + //
+						"        <value value=\"7610000050719\" />\n" + //
+						"    </identifier>\n" + //
+						"</Practitioner>";
+		
+		IBaseOperationOutcome operationOutcome = this.validationClient.validate(practitioner,"http://matchbox.health/ig/test/r4/StructureDefinition/practitioner-identifier-required");
+		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
 
+		ValidationReport report = this.validateWithGazelle(practitioner, "http://matchbox.health/ig/test/r4/StructureDefinition/practitioner-identifier-required");
+		assertEquals(0, getValidationFailures(report));
 	}
 
 	@Test

--- a/matchbox-server/src/test/resources/application-test-r4.yaml
+++ b/matchbox-server/src/test/resources/application-test-r4.yaml
@@ -37,6 +37,11 @@ matchbox:
       suppressError:
         hl7.fhir.r4.core#4.0.1:
           - "Extension_EXTP_Context_Wrong@^RelatedPerson"
+        matchbox.health.test.ig.r4#0.2.0:
+          - "Type_Specific_Checks_DT_URL_Resolve@^.*extension.*url"
+          - "Type_Specific_Checks_DT_URL_Resolve@^.*coding.*system"
+          - "Extension_EXT_Unknown"
+          - "Extension_EXT_Unknown_NotHere"
       xVersion: true
 spring:
   datasource:

--- a/matchbox-server/src/test/resources/application-test-r4b.yaml
+++ b/matchbox-server/src/test/resources/application-test-r4b.yaml
@@ -16,9 +16,12 @@ matchbox:
       httpReadOnly: true
       txServer: http://localhost:${server.port}/matchboxv3/fhir
       suppressWarnInfo:
-        hl7.fhir.r4b.core#4.0.1:
+        hl7.fhir.r4b.core#4.3.0:
           - "Constraint failed: dom-6:"
           - "regex:Entry '(.+)' isn't reachable by traversing forwards from the Composition"
+      suppressError:
+        hl7.fhir.r4b.core#4.3.0:
+          - "Extension_EXTP_Context_Wrong@^RelatedPerson"
 spring:
   datasource:
     url: "jdbc:h2:mem:test-r4b"

--- a/matchbox-server/src/test/resources/application-test-r5.yaml
+++ b/matchbox-server/src/test/resources/application-test-r5.yaml
@@ -15,6 +15,13 @@ matchbox:
     context:
       httpReadOnly: true
       txServer: http://localhost:${server.port}/matchboxv3/fhir
+      suppressWarnInfo:
+        hl7.fhir.r45.core#5.0.0:
+          - "Constraint failed: dom-6:"
+          - "regex:Entry '(.+)' isn't reachable by traversing forwards from the Composition"
+      suppressError:
+        hl7.fhir.r45.core#5.0.0:
+          - "Extension_EXTP_Context_Wrong@^RelatedPerson"
 spring:
   datasource:
     url: "jdbc:h2:mem:test-r5"

--- a/matchbox-server/src/test/resources/application-test-r5onr4.yaml
+++ b/matchbox-server/src/test/resources/application-test-r5onr4.yaml
@@ -27,6 +27,9 @@ matchbox:
     context:
       httpReadOnly: true
       txServer: http://localhost:${server.port}/matchboxv3/fhir
+      suppressError:
+        hl7.fhir.r4.core#4.0.1:
+          - "Extension_EXTP_Context_Wrong@^RelatedPerson"
 spring:
   datasource:
     url: "jdbc:h2:mem:test-r5onr4"

--- a/matchbox-server/with-gazelle/application.yaml
+++ b/matchbox-server/with-gazelle/application.yaml
@@ -1,0 +1,89 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /matchboxv3
+
+matchbox:
+  fhir:
+    context:
+      fhirVersion: 4.0.1
+      txServer: http://tx.fhir.org
+      httpReadOnly: true
+      suppressError:
+        hl7.fhir.r4.core#4.0.1:
+          - "Extension_EXTP_Context_Wrong@^RelatedPerson"
+        hl7.fhir.uv.ips:
+          - "Type_Specific_Checks_DT_URL_Resolve@^.*extension.*url"
+          - "Type_Specific_Checks_DT_URL_Resolve@^.*coding.*system"
+hapi:
+  fhir:
+    server_address: https://gazelle.ihe.net/matchboxv3/fhir
+    implementationguides:
+#      cda:
+#        url: https://github.com/ahdis/cda-core-2.0/releases/download/v0.0.3-dev/package.tgz
+#        name: hl7.fhir.cda
+#        version: 2.1.0
+#      cdach:
+#        url: http://build.fhir.org/ig/hl7ch/cda-fhir-maps/package.tgz
+#        name: ch.fhir.ig.cda-fhir-maps
+#        version: 0.3.0
+      fhir_r4_core:
+        name: hl7.fhir.r4.core
+        version: 4.0.1
+        url: classpath:/hl7.fhir.r4.core.tgz
+      fhir_r5_core:
+        name: hl7.fhir.r5.core
+        version: 5.0.0
+        url: classpath:/hl7.fhir.r5.core.tgz
+          #fhir_terminology:
+          #name: hl7.terminology
+          #version: 5.4.0
+          #url: classpath:/hl7.terminology#5.4.0.tgz
+      fhir_terminology:
+        name: hl7.terminology.r4
+        version: 6.3.0
+        url: classpath:/hl7.terminology.r4#6.3.0.tgz
+      fhir_extensions:
+        name: hl7.fhir.uv.extensions.r4
+        version: 5.2.0
+        url: classpath:/hl7.fhir.uv.extensions.r4#5.2.0.tgz
+      ips:
+        name: hl7.fhir.uv.ips
+        version: 1.1.0
+      ips100:
+        name: hl7.fhir.uv.ips
+        version: 1.0.0    
+      mhd:
+        name: ihe.iti.mhd
+        version: 4.2.1
+      pixm:
+        name: ihe.iti.pixm
+        version: 3.0.4
+      pdqm:
+        name: ihe.iti.pdqm
+        version: 3.0.0
+      balp:
+        name: ihe.iti.balp
+        version: 1.1.2
+#      quedm:
+#        name: ihe.pcc.qedm
+#        version: 0.0.1-current
+#        url: https://build.fhir.org/ig/oliveregger/QEDm/branches/oe_provenance/package.tgz
+      ira:
+        name: ihe.rad.ira
+        version: 1.0.0
+      imr:
+        name: ihe.rad.imr
+        version: 1.0.0
+      laboratory:
+        name: hl7.fhir.eu.laboratory
+        version: 0.1.0
+      ipa:
+        name: hl7.fhir.uv.ipa
+        version: 1.0.0
+      dsubm:
+        name: ihe.iti.dsubm
+        version: 1.0.0
+      svcm:
+        name: ihe.iti.svcm
+        version: 1.5.1

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or


### PR DESCRIPTION
## Summary by Sourcery

Enable suppressErrors support on the Gazelle validation endpoint and ensure it is honored by the validation engine.

New Features:
- Expose configured suppressedWarning and suppressedError patterns in Gazelle validation responses.
- Add new tests to verify suppressErrors behavior in both Gazelle and Matchbox API validation clients.

Enhancements:
- Ensure CLI context’s ImplementationGuide is set before engine configuration and skip null metadata fields.
- Update engine suppression logic to correctly apply error patterns across loaded IG packages.

Build:
- Upgrade project version from 4.0.7 to 4.0.8 in all POM files.

Documentation:
- Bump version to 4.0.8 and document the fix for suppressErrors in the changelog.

Tests:
- Update application-test YAML configurations to include suppressError entries for R4, R4B, R5, and R5-on-R4 profiles.
- Refactor existing tests for consistent formatting of FHIR resource literals.