### PR TITLE
resource references

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 2025/06/25 Release 4.0.9
 - unable to resolve resource with reference [#409](https://github.com/ahdis/matchbox/issues/409)
-- disableDefautlResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)
+- disableDefaultResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)
 
 2025/06/22 Release 4.0.8
 - suppressErrors not taken into account on gazelle interface [#405](https://github.com/ahdis/matchbox/issues/405)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
-2025/06/25 Release 4.0.9
+2025/07/01 Release 4.0.9
 - unable to resolve resource with reference [#409](https://github.com/ahdis/matchbox/issues/409)
-- disableDefaultResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)
+- disableDefautlResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)
+- update org.hl7.fhir.core 6.5.27 [#411](https://github.com/ahdis/matchbox/issues/411)
 
 2025/06/22 Release 4.0.8
 - suppressErrors not taken into account on gazelle interface [#405](https://github.com/ahdis/matchbox/issues/405)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2025/06/25 Release 4.0.9
+- unable to resolve resource with reference [#409](https://github.com/ahdis/matchbox/issues/409)
+- disableDefautlResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)
+
 2025/06/22 Release 4.0.8
 - suppressErrors not taken into account on gazelle interface [#405](https://github.com/ahdis/matchbox/issues/405)
 

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
@@ -64,6 +64,7 @@ import org.hl7.fhir.r5.utils.EOperationOutcome;
 import org.hl7.fhir.r5.utils.OperationOutcomeUtilities;
 import org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities;
 import org.hl7.fhir.r5.utils.validation.IResourceValidator;
+import org.hl7.fhir.r5.utils.validation.IValidationPolicyAdvisor;
 import org.hl7.fhir.r5.utils.validation.constants.ReferenceValidationPolicy;
 import org.hl7.fhir.utilities.ByteProvider;
 import org.hl7.fhir.utilities.FhirPublication;
@@ -1170,7 +1171,15 @@ public class MatchboxEngine extends ValidationEngine {
 	 * @param regexPath The regexPath to check.
 	 */
 	public void addSuppressedError(final @NonNull String messageId, final @NonNull String regexPath) {
-		((ch.ahdis.matchbox.engine.ValidationPolicyAdvisor) getPolicyAdvisor()).addSuppressedError(messageId, regexPath);
+		IValidationPolicyAdvisor advisor = getPolicyAdvisor();
+		while(advisor != null && !(advisor instanceof ch.ahdis.matchbox.engine.ValidationPolicyAdvisor)) {
+			advisor = advisor.getPolicyAdvisor();
+		}
+		if (advisor != null) {
+			((ch.ahdis.matchbox.engine.ValidationPolicyAdvisor) advisor).addSuppressedError(messageId, regexPath);
+		} else {
+			log.error("ValidationPolicyAdvisor not found to add suppressed error for messageId: " + messageId + " and regexPath: " + regexPath);
+		}
 	}
 
 	/**
@@ -1204,7 +1213,14 @@ public class MatchboxEngine extends ValidationEngine {
 	 * Returns the list of suppressed validation error issues.
 	 */
 	public List<String> getSuppressedErrors() {
-		return ((ch.ahdis.matchbox.engine.ValidationPolicyAdvisor) getPolicyAdvisor()).getSuppressedErrorMessages();
+		IValidationPolicyAdvisor advisor = getPolicyAdvisor();
+		while(advisor != null && !(advisor instanceof ch.ahdis.matchbox.engine.ValidationPolicyAdvisor)) {
+			advisor = advisor.getPolicyAdvisor();
+		}
+		if (advisor != null) {
+			return ((ch.ahdis.matchbox.engine.ValidationPolicyAdvisor) advisor).getSuppressedErrorMessages();
+		}
+		return null;
 	}
 
 	/**

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/cli/MatchboxCli.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/cli/MatchboxCli.java
@@ -42,13 +42,14 @@ import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.validation.Scanner;
 import org.hl7.fhir.validation.service.model.ValidationContext;
-import org.hl7.fhir.validation.service.utils.Display;
 import org.hl7.fhir.validation.service.utils.EngineMode;
+import org.hl7.fhir.validation.cli.Display;
 import org.hl7.fhir.validation.cli.param.Params;
 import org.hl7.fhir.validation.testexecutor.TestExecutor;
 import org.hl7.fhir.validation.testexecutor.TestExecutorParams;
 
 import ch.ahdis.matchbox.engine.MatchboxEngine;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -58,6 +59,7 @@ import ch.ahdis.matchbox.engine.MatchboxEngine;
  *
  * @author Oliver Egger
  */
+@Slf4j
 public class MatchboxCli {
 
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
@@ -75,7 +77,7 @@ public class MatchboxCli {
     TimeTracker.Session tts = tt.start("Loading");
     
     System.out.println(VersionUtil.getPoweredBy());
-    Display.displaySystemInfo(System.out);
+    Display.displaySystemInfo(log);
 
     if (Params.hasParam(args, Params.PROXY)) {
       assert Params.getParam(args, Params.PROXY) != null : "PROXY arg passed in was NULL";
@@ -122,12 +124,12 @@ public class MatchboxCli {
     FileFormat.checkCharsetAndWarnIfNotUTF8(System.out);
 
     if (shouldDisplayHelpToUser(args)) {
-      Display.displayHelpDetails(System.out, "help/help.txt");
+      Display.displayHelpDetails(log, "help/help.txt");
     } else if (Params.hasParam(args, Params.TEST)) {
       parseTestParamsAndExecute(args);
     }
     else {
-      Display.printCliParamsAndInfo(args);
+      Display.printCliParamsAndInfo(log,args);
       doValidation(tt, tts, validationContext);
     }
   }

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/cli/MatchboxService.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/cli/MatchboxService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.hl7.fhir.r5.context.ContextUtilities;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
-import org.hl7.fhir.r5.context.SystemOutLoggingService;
+import org.hl7.fhir.r5.context.Slf4JLoggingService;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.formats.IParser;
@@ -31,6 +31,7 @@ import org.hl7.fhir.validation.IgLoader;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.ValidationRecord;
 import org.hl7.fhir.validation.ValidatorUtils;
+import org.hl7.fhir.validation.instance.advisor.BasePolicyAdvisorForFullValidation;
 import org.hl7.fhir.validation.service.model.ValidationContext;
 import org.hl7.fhir.validation.service.model.FileInfo;
 import org.hl7.fhir.validation.service.model.ValidationOutcome;
@@ -41,6 +42,7 @@ import org.hl7.fhir.validation.service.renderers.DefaultRenderer;
 import org.hl7.fhir.validation.service.renderers.ESLintCompactRenderer;
 import org.hl7.fhir.validation.service.renderers.NativeRenderer;
 import org.hl7.fhir.validation.service.renderers.ValidationOutputRenderer;
+import org.hl7.fhir.validation.service.DisabledValidationPolicyAdvisor;
 import org.hl7.fhir.validation.service.HTMLOutputGenerator;
 import org.hl7.fhir.validation.service.PassiveExpiringSessionCache;
 import org.hl7.fhir.validation.service.StandAloneValidatorFetcher;
@@ -50,6 +52,7 @@ import org.hl7.fhir.validation.service.utils.VersionSourceInformation;
 import ch.ahdis.matchbox.engine.CdaMappingEngine;
 import ch.ahdis.matchbox.engine.MatchboxEngine;
 import ch.ahdis.matchbox.engine.ValidationPolicyAdvisor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A executable class 
@@ -58,6 +61,7 @@ import ch.ahdis.matchbox.engine.ValidationPolicyAdvisor;
  *
  * @author Oliver Egger
  */
+@Slf4j
 public class MatchboxService {
 
   public static final String CURRENT_DEFAULT_VERSION = "4.0";
@@ -388,7 +392,7 @@ public class MatchboxService {
       sessionId = sessionCache.cacheSession(validator);
 
       validator.setDebug(validationContext.isDoDebug());
-      validator.getContext().setLogger(new SystemOutLoggingService(validationContext.isDoDebug()));
+      validator.getContext().setLogger(new Slf4JLoggingService(log));
       for (String src : validationContext.getIgs()) {
         validator.getIgLoader().loadIg(validator.getIgs(), validator.getBinaries(), src, validationContext.isRecursive());
       }
@@ -420,6 +424,8 @@ public class MatchboxService {
       validator.setForPublication(validationContext.isForPublication());
       validator.setShowTimes(validationContext.isShowTimes());
       validator.setAllowExampleUrls(validationContext.isAllowExampleUrls());
+      validator.setR5BundleRelativeReferencePolicy(validationContext.getR5BundleRelativeReferencePolicy());
+      ReferenceValidationPolicy refpol = ReferenceValidationPolicy.CHECK_VALID;
       if (!validationContext.isDisableDefaultResourceFetcher()) {
           StandAloneValidatorFetcher fetcher = new StandAloneValidatorFetcher(validator.getPcm(), validator.getContext(), validator);
           validator.setFetcher(fetcher);
@@ -432,12 +438,11 @@ public class MatchboxService {
           }
           fetcher.setResolutionContext(validationContext.getResolutionContext());
         } else {
-          validator.setPolicyAdvisor(new ValidationPolicyAdvisor(ReferenceValidationPolicy.CHECK_VALID));
-          // https://github.com/ahdis/matchbox/issues/334
-//          DisabledValidationPolicyAdvisor fetcher = new DisabledValidationPolicyAdvisor();
-//          validator.setPolicyAdvisor(fetcher);
-//          refpol = ReferenceValidationPolicy.CHECK_TYPE_IF_EXISTS;
+          DisabledValidationPolicyAdvisor fetcher = new DisabledValidationPolicyAdvisor();
+          validator.setPolicyAdvisor(fetcher);
+          refpol = ReferenceValidationPolicy.CHECK_TYPE_IF_EXISTS;
       }
+      validator.getPolicyAdvisor().setPolicyAdvisor(new ValidationPolicyAdvisor(validator.getPolicyAdvisor() == null ? refpol : validator.getPolicyAdvisor().getReferencePolicy()));
       validator.getBundleValidationRules().addAll(validationContext.getBundleValidationRules());
       validator.setJurisdiction(CodeSystemUtilities.readCoding(validationContext.getJurisdiction()));
       

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -1067,7 +1067,7 @@ public class XmlParser extends ParserBase {
         } 
       }
       if (e != null && !"UTF-8".equalsIgnoreCase(e)) {
-        logError(errors, ValidationMessage.NO_RULE_DATE, 0, 0, "XML", IssueType.INVALID, context.formatMessage(I18nConstants.XML_ENCODING_INVALID), IssueSeverity.ERROR);
+        logError(errors, ValidationMessage.NO_RULE_DATE, 0, 0, "XML", IssueType.INVALID, context.formatMessage(I18nConstants.XML_ENCODING_INVALID, e), IssueSeverity.ERROR);
       }
 
       i = header.indexOf("version=\"");

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -740,8 +740,14 @@ public class XmlParser extends ParserBase {
   public void compose(Element e, OutputStream stream, OutputStyle style, String base) throws IOException, FHIRException {
     markedXhtml = false;
     XMLWriter xml = new XMLWriter(stream, "UTF-8");
-    xml.setSortAttributes(false);
     xml.setPretty(style == OutputStyle.PRETTY);
+    if (style == OutputStyle.CANONICAL) {
+      xml.setXmlHeader(false);
+      xml.setIgnoreComments(true);
+      xml.setCanonical(true);
+    } else {
+      xml.setCanonical(false);
+    }
     xml.start();
     if (e.getPath() == null) {
       e.populatePaths(null);
@@ -824,6 +830,9 @@ public class XmlParser extends ParserBase {
   }
 
   private void composeElement(IXMLWriter xml, Element element, String elementName, boolean root) throws IOException, FHIRException {
+    if (canonicalFilter.contains(element.getPath())) {
+      return;
+    }
     if (!(isElideElements() && element.isElided())) {
       if (showDecorations) {
         @SuppressWarnings("unchecked")
@@ -852,7 +861,7 @@ public class XmlParser extends ParserBase {
         xml.text(element.getValue());
         xml.exit(element.getProperty().getXmlNamespace(),elementName);
       }
-    } else if (!element.hasChildren() && !element.hasValue()) {
+    } else if (!element.hasChildren() && !element.hasValue() && !element.hasXhtml()) {
       if (isElideElements() && element.isElided() && xml.canElide())
         xml.elide();
       else {
@@ -865,11 +874,15 @@ public class XmlParser extends ParserBase {
         if (isElideElements() && element.isElided() && xml.canElide())
           xml.elide();
         else {
-          String rawXhtml = element.getValue();
           if (isCdaText(element.getProperty())) {
-            new CDANarrativeFormat().convert(xml, new XhtmlParser().parseFragment(rawXhtml));
+            new CDANarrativeFormat().convert(xml, element.getXhtml());
           } else {
-            xml.escapedText(rawXhtml);
+            if (element.getXhtml() != null) {
+               String xhtml = new XhtmlComposer(XhtmlComposer.XML, false).setCanonical(xml.isCanonical()).compose(element.getXhtml());            
+               xml.escapedText(xhtml);
+            } else {
+               xml.escapedText(element.getValue());
+            }
             if (!markedXhtml) {
               xml.anchor("end-xhtml");
               markedXhtml = true;

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/testfactory/TestDataFactory.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/testfactory/TestDataFactory.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.context.IWorkerContext;
@@ -48,9 +49,8 @@ import org.hl7.fhir.utilities.json.JsonException;
 import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.json.parser.JsonParser;
 
-import ca.uhn.fhir.context.support.IValidationSupport.ValueSetExpansionOutcome;
-
 @MarkedToMoveToAdjunctPackage
+@Slf4j
 public class TestDataFactory {
 
   public static class DataTable extends Base {
@@ -214,7 +214,7 @@ public class TestDataFactory {
   
   private String rootFolder;
   private LiquidEngine liquid;
-  private PrintStream log;
+  private PrintStream testLog;
   private IWorkerContext context;
   private String canonical;
   private FhirFormat format;
@@ -241,7 +241,7 @@ public class TestDataFactory {
     if (Utilities.noString(name)) {
       throw new FHIRException("Factory has no name");
     }
-    log = new PrintStream(new FileOutputStream(Utilities.path(logFolder, name+".log"))); 
+    testLog = new PrintStream(new FileOutputStream(Utilities.path(logFolder, name+".log")));
     format = "json".equals(details.asString("format")) ? FhirFormat.JSON : FhirFormat.XML;
   }
   
@@ -259,7 +259,7 @@ public class TestDataFactory {
       error("Factory "+getName()+" mode '"+mode+"' unknown");
     }
     log("finished successfully");
-    log.close();
+    testLog.close();
   }
   
 
@@ -291,7 +291,7 @@ public class TestDataFactory {
       }
       logDataScheme(tbl, tables);
       ProfileBasedFactory factory = new ProfileBasedFactory(fpe, localData.getAbsolutePath(), tbl, tables, details.forceArray("mappings"));
-      factory.setLog(log);
+      factory.setLog(testLog);
       factory.setTesting(testing);
       factory.setMarkProfile(details.asBoolean("mark-profile"));
       String purl = details.asString( "profile");
@@ -319,9 +319,9 @@ public class TestDataFactory {
         }
       }
     } catch (Exception e) {
-      System.out.println("Error running test factory '"+getName()+"': "+e.getMessage());
+      log.error("Error running test factory '"+getName()+"': "+e.getMessage());
       log("Error running test case '"+getName()+"': "+e.getMessage());
-      e.printStackTrace(log);
+      e.printStackTrace(testLog);
       throw new FHIRException(e);
     }
   }
@@ -397,12 +397,12 @@ public class TestDataFactory {
 
   private void error(String msg) throws IOException {
     log(msg);
-    log.close();
+    testLog.close();
     throw new FHIRException(msg);
   }
 
   private void log(String msg) throws IOException {
-    log.append(msg+"\r\n");    
+    testLog.append(msg+"\r\n");
   }
 
   public void executeLiquid() throws IOException {
@@ -434,9 +434,9 @@ public class TestDataFactory {
         }
       }
     } catch (Exception e) {
-      System.out.println("Error running test factory '"+getName()+"': "+e.getMessage());
+      log.error("Error running test factory '"+getName()+"': "+e.getMessage());
       log("Error running test case '"+getName()+"': "+e.getMessage());
-      e.printStackTrace(log);
+      e.printStackTrace(testLog);
       throw new FHIRException(e);
     }
   }

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -33,7 +33,7 @@ package org.hl7.fhir.r5.utils.structuremap;
 // remember group resolution
 // trace - account for which wasn't transformed in the source
 
-import net.sourceforge.plantuml.utils.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.exceptions.DefinitionException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.FHIRFormatError;
@@ -102,6 +102,7 @@ import java.util.*;
  * @author Grahame Grieve
  */
 @MarkedToMoveToAdjunctPackage
+@Slf4j
 public class StructureMapUtilities {
 
   public static final String MAP_WHERE_CHECK = "map.where.check";
@@ -651,7 +652,7 @@ public class StructureMapUtilities {
     Element res = fp.parse(errors, Utilities.stripBOM(text));
     // matchbox patch FML lexer errors swallowed #367
     if (res == null || errors.size() > 0) {
-      Log.error(errors.toString());
+      log.error(errors.toString());
       throw new FHIRException("Unable to parse Map Source for "+srcName + " Details "+errors.toString());
     }
     ByteArrayOutputStream boas = new ByteArrayOutputStream();
@@ -688,9 +689,8 @@ public class StructureMapUtilities {
     if (debug) {
       if (getServices() != null)
         getServices().log(cnt);
-      else
-        System.out.println(cnt);
     }
+    log.debug(cnt);
   }
 
   /**

--- a/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/Display.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/Display.java
@@ -1,0 +1,95 @@
+package org.hl7.fhir.validation.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.utilities.VersionUtil;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+import org.slf4j.Logger;
+
+/**
+ * Class for displaying output to the cli user.
+ * <p>
+ * TODO - Clean this up for localization
+ */
+public class Display {
+
+
+  private static String toMB(long maxMemory) {
+    return Long.toString(maxMemory / (1024 * 1024));
+  }
+
+  public static void printCliParamsAndInfo(Logger logger, String[] args) throws IOException {
+   logger.info("  Paths:  Current = " + System.getProperty("user.dir") + ", Package Cache = " + new FilesystemPackageCacheManager.Builder().build().getFolder());
+   StringBuilder sb = new StringBuilder();
+   for (String s : args) {
+     if (s.contains(" ")) {
+       sb.append(" \"").append(s).append("\"");
+     } else {
+       sb.append(" ").append(s);
+     }
+   }
+
+   logger.info("  Params:" + sb.toString());
+  }
+
+  final static String CURLY_START = "\\{\\{";
+  final static String CURLY_END = "\\}\\}";
+
+  final static String getMoustacheString(final String string) {
+    return CURLY_START + string + CURLY_END;
+  }
+
+
+
+  final static String replacePlaceholders(final String input, final String[][] placeholders) {
+    String output = input;
+    for (String[] placeholder : placeholders) {
+      output = output.replaceAll(getMoustacheString(placeholder[0]), placeholder[1]);
+    }
+    return output;
+  }
+
+  public static void displayHelpDetails(Logger logger, String file) {
+    displayHelpDetails(logger, file, new String[][]{});
+  }
+  /**
+   * Loads the help details from a file, and displays them on the out stream.
+   *
+   * @param logger
+   * @param file
+   */
+  public static void displayHelpDetails(Logger logger, String file, final String[][] placeholders) {
+    ClassLoader classLoader = Display.class.getClassLoader();
+    InputStream help = classLoader.getResourceAsStream(file);
+    try {
+      String data = IOUtils.toString(help, "UTF-8");
+
+      logger.info(replacePlaceholders(data, placeholders));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+
+
+  /**
+   * Prints out system info to the command line.
+   */
+  public static void displaySystemInfo(Logger logger) {
+    logger.info("  Java:   " + System.getProperty("java.version")
+      + " from " + System.getProperty("java.home")
+      + " on " + System.getProperty("os.arch")
+      + " (" + System.getProperty("sun.arch.data.model") + "bit). "
+      + toMB(Runtime.getRuntime().maxMemory()) + "MB available");
+  }
+
+  /**
+   * Prints current version of the validator.
+   */
+  public static void displayVersion(Logger logger) {
+    logger.info("FHIR Validation tool " + VersionUtil.getVersionString());
+  }
+}

--- a/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
@@ -133,6 +133,7 @@ public class Params {
   public static final String TEST_MODULES = "-test-modules";
 
   public static final String TEST_NAME_FILTER = "-test-classname-filter";
+  public static final String CERT = "-cert";
   public static final String SPECIAL = "-special";
   public static final String TARGET = "-target";
   public static final String SOURCE = "-source";
@@ -147,6 +148,7 @@ public class Params {
   public static final String NO_HTTP_ACCESS = "-no-http-access";
   public static final String AUTH_NONCONFORMANT_SERVERS = "-authorise-non-conformant-tx-servers";
   public static final String R5_REF_POLICY = "r5-bundle-relative-reference-policy";
+  public static final String MATCHETYPE = "-matchetype";
 
   /**
    * Checks the list of passed in params to see if it contains the passed in param.
@@ -500,7 +502,28 @@ public class Params {
           throw new Error("Specified -txCache without indicating file");
         else
           validationContext.setTxCache(args[++i]);
-      } else if (args[i].equals(LOG)) {
+      } else if (args[i].equals(CERT)) {
+        if (i + 1 == args.length)
+          throw new Error("Specified -txCache without indicating file");
+        else {
+          String s = args[++i];
+          if (!(new File(s).exists())) {
+            throw new Error("Certificate source '"+s+"'  not found");            
+          } else {
+            validationContext.getCertSources().add(s);
+          }
+        }
+      } else if (args[i].equals(MATCHETYPE)) {
+        if (i + 1 == args.length)
+          throw new Error("Specified -matchetype without indicating file");
+        else {
+          String s = args[++i];
+          if (!(new File(s).exists())) {
+            throw new Error("-matchetype source '"+s+"'  not found");            
+          } else {
+            validationContext.getMatchetypes().add(s);
+          }
+        }} else if (args[i].equals(LOG)) {
         if (i + 1 == args.length)
           throw new Error("Specified -log without indicating file");
         else

--- a/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.terminologies.JurisdictionUtilities;
@@ -21,6 +22,7 @@ import org.hl7.fhir.validation.service.utils.EngineMode;
 import org.hl7.fhir.validation.service.utils.QuestionnaireMode;
 import org.hl7.fhir.validation.service.utils.ValidationLevel;
 
+@Slf4j
 public class Params {
 
   public static final String VERSION = "-version";
@@ -46,6 +48,8 @@ public class Params {
   public static final String CHECK_REFERENCES = "-check-references";
   public static final String RESOLUTION_CONTEXT = "-resolution-context";
   public static final String DEBUG = "-debug";
+  public static final String DEBUG_LOG = "-debug-log";
+  public static final String TRACE_LOG = "-trace-log";
   public static final String SCT = "-sct";
   public static final String RECURSE = "-recurse";
   public static final String SHOW_MESSAGES_FROM_REFERENCES = "-showReferenceMessages";
@@ -201,6 +205,10 @@ public class Params {
           throw new Error("Specified -html-output without indicating output file");
         else
           validationContext.setHtmlOutput(args[++i]);
+      } else if (args[i].equals(DEBUG_LOG)) {
+        i++;
+      } else if (args[i].equals(TRACE_LOG)) {
+        i++;
       } else if (args[i].equals(PROXY)) {
         i++; // ignore next parameter
       } else if (args[i].equals(PROXY_AUTH)) {
@@ -294,7 +302,8 @@ public class Params {
       } else if (args[i].equals(RESOLUTION_CONTEXT)) {
         validationContext.setResolutionContext(args[++i]);
       } else if (args[i].equals(DEBUG)) {
-        validationContext.setDoDebug(true);
+        //FIXME warm that debug now outputs to the log file
+        //validationContext.setDoDebug(true);
       } else if (args[i].equals(SCT)) {
         validationContext.setSnomedCT(args[++i]);
       } else if (args[i].equals(RECURSE)) {
@@ -664,7 +673,7 @@ public class Params {
         else {
           String s = args[++i];
           if (!s.startsWith("hl7.fhir.core-")) {
-            System.out.println("Load Package: " + s);
+            log.info("Load Package: " + s);
           }
         }
       }

--- a/matchbox-engine/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
@@ -8,14 +8,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.model.Base.ValidationMode;
-import org.hl7.fhir.r5.model.Coding;
-import org.hl7.fhir.r5.model.Constants;
 import org.hl7.fhir.r5.model.Enumerations.FHIRVersion;
 import org.hl7.fhir.r5.model.StructureDefinition;
-import org.hl7.fhir.r5.utils.XVerExtensionManager;
 import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
@@ -24,10 +20,8 @@ import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
 import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.instance.InstanceValidator;
-import org.hl7.fhir.validation.instance.PercentageTracker;
-import org.hl7.fhir.validation.instance.type.BundleValidator.StringWithSource;
+import org.hl7.fhir.validation.instance.ResourcePercentageLogger;
 import org.hl7.fhir.validation.instance.utils.EntrySummary;
-import org.hl7.fhir.validation.instance.utils.IndexedElement;
 import org.hl7.fhir.validation.instance.utils.NodeStack;
 import org.hl7.fhir.validation.instance.utils.ValidationContext;
 
@@ -73,7 +67,7 @@ public class BundleValidator extends BaseValidator {
     this.serverBase = serverBase;
   }
 
-  public boolean validateBundle(List<ValidationMessage> errors, Element bundle, NodeStack stack, boolean checkSpecials, ValidationContext hostContext, PercentageTracker pct, ValidationMode mode) {
+  public boolean validateBundle(List<ValidationMessage> errors, Element bundle, NodeStack stack, boolean checkSpecials, ValidationContext hostContext, ResourcePercentageLogger pct, ValidationMode mode) {
     boolean ok = true;
     
     String type = bundle.getNamedChildValue(TYPE, false);
@@ -691,7 +685,6 @@ public class BundleValidator extends BaseValidator {
       foundRevLinks = false;
       for (EntrySummary e : entryList) {
         if (!visited.contains(e)) {
-//          System.out.println("Not visited "+e.getIndex()+" - check for reverse links");             
           boolean add = false;
           for (EntrySummary t : e.getTargets()) {
             if (visited.contains(t)) {

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -151,11 +151,6 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 	}
 
 	@Override
-	public void setSilent(boolean silent) {
-		myPackageLoaderSvc.setSilent(silent);
-	}
-
-	@Override
 	public String getPackageUrl(String theS) throws IOException {
 		return myPackageLoaderSvc.getPackageUrl(theS);
 	}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/CliContext.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/CliContext.java
@@ -285,6 +285,9 @@ public class CliContext {
   @JsonProperty("check-references")
   private boolean checkReferences = false;
 
+  @JsonProperty("r5-bundle-relative-reference-policy")
+  private String r5BundleRelativeReferencePolicy = "default";
+
   // @JsonProperty("showTimes")
   // private boolean showTimes = false;
 
@@ -802,6 +805,17 @@ public class CliContext {
     this.analyzeOutcomeWithAIOnError = analyzeOutcomeWithAIOnError;
   }
 
+  @JsonProperty("r5-bundle-relative-reference-policy")
+  public String getR5BundleRelativeReferencePolicy() {
+    return r5BundleRelativeReferencePolicy;
+  }
+
+  @JsonProperty("r5-bundle-relative-reference-policy")
+  public void setR5BundleRelativeReferencePolicy(String r5BundleRelativeReferencePolicy) {
+    this.r5BundleRelativeReferencePolicy = r5BundleRelativeReferencePolicy;
+  }
+
+
   @Override
   public boolean equals(final Object o) {
     if (this == o)
@@ -859,7 +873,8 @@ public class CliContext {
         && Objects.equals(bundle, that.bundle)
         && Arrays.equals(suppressErrors, that.suppressErrors)
         && Arrays.equals(suppressWarnInfos, that.suppressWarnInfos)
-        && Arrays.equals(igs, that.igs);
+        && Arrays.equals(igs, that.igs)
+        && Objects.equals(r5BundleRelativeReferencePolicy, that.r5BundleRelativeReferencePolicy);
   }
 
   @Override
@@ -909,7 +924,8 @@ public class CliContext {
         llmModelName,
         llmApiKey,
         checkIpsCodes,
-        bundle);
+        bundle,
+        r5BundleRelativeReferencePolicy);
     result = 31 * result + Arrays.hashCode(igsPreloaded);
     result = 31 * result + Arrays.hashCode(extensions);
     result = 31 * result + Arrays.hashCode(suppressErrors);
@@ -963,6 +979,7 @@ public class CliContext {
         ", httpReadOnly=" + httpReadOnly +
         ", checkReferences=" + checkReferences +
         ", resolutionContext=" + resolutionContext +
+        ", r5-bundle-relative-reference-policy='" + r5BundleRelativeReferencePolicy + '\'' +
         ", disableDefaultResourceFetcher=" + disableDefaultResourceFetcher +
         ", analyzeOutcomeWithAI=" + analyzeOutcomeWithAI +
         ", analyzeOutcomeWithAIOnError=" + analyzeOutcomeWithAIOnError +
@@ -1027,6 +1044,7 @@ public class CliContext {
     addExtension(ext, "jurisdiction", new StringType(this.jurisdiction));
     addExtension(ext, "check-references", new BooleanType(this.checkReferences));
     addExtension(ext, "resolution-context", new StringType(this.resolutionContext));
+    addExtension(ext, "r5-bundle-relative-reference-policy", new StringType(this.r5BundleRelativeReferencePolicy));
     addExtension(ext, "disableDefaultResourceFetcher", new BooleanType(this.disableDefaultResourceFetcher));
     addExtension(ext, "analyzeOutcomeWithAI", new BooleanType(this.analyzeOutcomeWithAI));
     addExtension(ext, "analyzeOutcomeWithAIOnError", new BooleanType(this.analyzeOutcomeWithAIOnError));

--- a/matchbox-server/with-gazelle/application.yaml
+++ b/matchbox-server/with-gazelle/application.yaml
@@ -15,6 +15,8 @@ matchbox:
         hl7.fhir.uv.ips:
           - "Type_Specific_Checks_DT_URL_Resolve@^.*extension.*url"
           - "Type_Specific_Checks_DT_URL_Resolve@^.*coding.*system"
+          - "Extension_EXT_Unknown_NotHere"
+          - "Extension_EXT_Unknown"
 hapi:
   fhir:
     server_address: https://gazelle.ihe.net/matchboxv3/fhir

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <fhir.core.version>6.5.25</fhir.core.version>
+        <fhir.core.version>6.5.26</fhir.core.version>
         <hapi.fhir.version>8.0.0</hapi.fhir.version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.0.8</version>
+    <version>4.0.9</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -40,7 +40,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <fhir.core.version>6.5.26</fhir.core.version>
+        <fhir.core.version>6.5.27</fhir.core.version>
         <hapi.fhir.version>8.0.0</hapi.fhir.version>
 
 

--- a/updatehapi.sh
+++ b/updatehapi.sh
@@ -10,6 +10,7 @@ cp ../org.hl7.fhir.core/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/valid
 cp ../org.hl7.fhir.core/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java matchbox-engine/src/main/java/org/hl7/fhir/validation/
 cp ../org.hl7.fhir.core/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/testfactory/TestDataFactory.java matchbox-engine/src/main/java/org/hl7/fhir/r5/testfactory/
 cp ../org.hl7.fhir.core/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java matchbox-engine/src/main/java/org/hl7/fhir/validation/cli/param
+cp ../org.hl7.fhir.core/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/Display.java matchbox-engine/src/main/java/org/hl7/fhir/validation/cli
 # cp ../hapi-fhir/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ResourceParameter.java matchbox-server/src/main/java/ca/uhn/fhir/rest/server/method
 # cp ../hapi-fhir/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java matchbox-server/src/main/java/ca/uhn/fhir/rest/server
 # cp ../hapi-fhir/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/loader/PackageLoaderSvc.java matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/loader/


### PR DESCRIPTION
- unable to resolve resource with reference [#409](https://github.com/ahdis/matchbox/issues/409)
- disableDefautlResource Fetcher provokes an error [#408](https://github.com/ahdis/matchbox/issues/408)

## Summary by Sourcery

Improve logging (SLF4J), reference resolution, and configurability: replace System.out calls, migrate to ResourcePercentageLogger, introduce duplicate ID checks, allow suppression of errors/warnings, add CLI Display helper, expose suppressed patterns in Gazelle interface, and bump version to 4.0.8.

New Features:
- Introduce a new CLI Display utility class for structured user output
- Add a new 'r5-bundle-relative-reference-policy' option to configure bundle reference behavior
- Expose suppressed warning/error patterns in Gazelle validation responses

Bug Fixes:
- Resolve issue where internal resource references were not found by switching reference collector to lists (fixes #409)
- Prevent errors when disabling the default resource fetcher by correctly wiring the policy advisor (fixes #408)

Enhancements:
- Replace direct System.out prints with SLF4J logging across the codebase and add @Slf4j annotations
- Switch from PercentageTracker to ResourcePercentageLogger for progress reporting
- Add duplicate XHTML ID detection and warning in instance validation
- Refactor debug printing into a dedicated debugElement method
- Bump project version to 4.0.8 and upgrade fhir.core dependency to 6.5.26

Documentation:
- Update changelog with recent fixes and releases

Tests:
- Add tests for suppressing validation errors and ignoring unknown extensions in both server and engine modules