### PR TITLE
ADTT-777: Update SonarQube Pipeline.

### DIFF
--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -37,11 +37,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd matchbox-engine
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+          mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd matchbox-server
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+          mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
           

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -36,8 +36,13 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          # cd matchbox-engine
-          mvn -B --no-transfer-progress -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+          export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=error"
+          mvn -B --no-transfer-progress -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation -l build.log
+      - name: Upload build log
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: build.log          
       # - name: Build and analyze
       #   env:
       #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -33,6 +33,7 @@ jobs:
           key: ${{ runner.os }}-m2
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
+        continue-on-error: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=error"
           mvn -B --no-transfer-progress -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation -l build.log
+      # Log is too large and so we are creating a log file and uploading it.
+      # this is why we need continue on error on the step above.
       - name: Upload build log
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -36,12 +36,12 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          cd matchbox-engine
-          mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
-      - name: Build and analyze
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          cd matchbox-server
-          mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+          # cd matchbox-engine
+          mvn -B --no-transfer-progress -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+      # - name: Build and analyze
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #   run: |
+      #     cd matchbox-server
+      #     mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
           

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -1,0 +1,47 @@
+name: SonarQube
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 2'  # Runs every Monday at 00:00 UTC
+    
+jobs:
+  build:
+    name: Build and Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'zulu'
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          cd matchbox-engine
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          cd matchbox-server
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
+          

--- a/.github/workflows/java-sonar-build.yml
+++ b/.github/workflows/java-sonar-build.yml
@@ -44,10 +44,4 @@ jobs:
         with:
           name: build-log
           path: build.log          
-      # - name: Build and analyze
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #   run: |
-      #     cd matchbox-server
-      #     mvn -B -q verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=AccessDigitalHealth_cicd-jira-automation
           

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>21</maven.compiler.release>
-
         <fhir.core.version>6.5.21</fhir.core.version>
         <hapi.fhir.version>8.0.0</hapi.fhir.version>
+        <sonar.organization>accessdigitalhealth</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
 
         <!-- The following section closely matches the one of HAPI-FHIR (for easier version comparison/upgrade).


### PR DESCRIPTION
* Add support for SonarQube execution

## Summary by Sourcery

Configure SonarCloud analysis by adding SonarQube properties to the Maven build and introducing a GitHub Actions workflow to run scheduled, manual, and on-push scans

Build:
- Add SonarCloud properties (sonar.organization and sonar.host.url) to the Maven POM

CI:
- Add java-sonar-build GitHub Actions workflow to perform SonarQube analysis on push, scheduled cron jobs, and manual triggers