### PR TITLE
Update execution order in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ or
 ### Configurable base image:
 
 ```bash
-cd matchbox-server
 mvn package -DskipTests
+cd matchbox-server
 docker build -t matchbox .
 docker run -d --name matchbox -p 8080:8080 -v /Users/oegger/Documents/github/matchbox/matchbox-server/with-settings:/config matchbox
 ```


### PR DESCRIPTION
mvn has to be executed in the root directory. docker will then be executed within matchbox-server

## Summary by Sourcery

Documentation:
- Update README build section to remove premature cd and run mvn package from the root directory before entering matchbox-server for Docker steps