### PR TITLE
update to 4.0.11

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+2025/08/12 Release 4.0.11
+- update for scanned vulnerabilities
+
 2025/08/07 Release 4.0.10
 - update org.hl7.fhir.core 6.6.3 [#415](https://github.com/ahdis/matchbox/issues/415)
 - document validation parameters [#407](https://github.com/ahdis/matchbox/issues/407)

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>
@@ -27,6 +27,12 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
         <!-- This dependency includes the core HAPI-FHIR classes -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
@@ -72,6 +78,12 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-jpaserver-mdm</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- This dependency includes the JPA CQL Server -->
         <!-- This dependency includes the OpenAPI Server -->
@@ -158,6 +170,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
         </dependency>
 
         <dependency>

--- a/matchbox-server/with-alis/application.yaml
+++ b/matchbox-server/with-alis/application.yaml
@@ -10,7 +10,7 @@ hapi:
         version: 4.0.1
         url: classpath:/hl7.fhir.r4.core.tgz
       fhir_extensions:
-        name: hl7.fhir.uv.extensions.4
+        name: hl7.fhir.uv.extensions.r4
         version: 5.2.0
         url: classpath:/hl7.fhir.uv.extensions.r4#5.2.0.tgz
       fhir_terminology:
@@ -19,7 +19,7 @@ hapi:
         url: classpath:/hl7.terminology.r4#6.3.0.tgz
       hl7_fhir_uv_ips:
         name: ch.fhir.ig.ch-alis
-        version: 0.3.0
+        version: 0.3.0-draft
         url: file:/Users/oegger/Documents/github/ch-alis/output/package.tgz
     staticLocation: file:/apps/
 matchbox:

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.0.10</version>
+    <version>4.0.11</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -51,12 +51,14 @@
         <commons_compress_version>1.27.1</commons_compress_version>
         <commons_dbcp2_version>2.12.0</commons_dbcp2_version>
         <commons_io_version>2.17.0</commons_io_version>
+        <commons_lang3_version>3.18.0</commons_lang3_version>
         <junit_version>5.13.1</junit_version>
         <logback_version>1.5.16</logback_version>
         <jackson_version>2.17.1</jackson_version>
         <okhttp_version>4.12.0</okhttp_version>
         <log4j_to_slf4j_version>2.19.0</log4j_to_slf4j_version>
-        <spring_version>6.1.15</spring_version>
+        <spring_version>6.1.21</spring_version>
+        <spring_context_version>6.1.20</spring_context_version>
         <spring_boot_version>3.3.11</spring_boot_version>
         <testcontainers_version>1.21.1</testcontainers_version>
         <ucum_version>1.0.10</ucum_version>
@@ -66,6 +68,7 @@
         <awaitility_version>4.2.0</awaitility_version>
         <xmlunit_version>2.10.0</xmlunit_version>
         <beanutils_version>1.11.0</beanutils_version>
+
 
 
         <org_commonmark_version>0.21.0</org_commonmark_version>
@@ -97,7 +100,7 @@
 
         <excludePackageNames>org.hl7.*:ca.uhn.*</excludePackageNames>
 
-        <apache_poi_version>5.2.1</apache_poi_version>
+        <apache_poi_version>5.4.0</apache_poi_version>
 
     </properties>
 
@@ -174,6 +177,17 @@
                 <version>${org_commonmark_version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons_lang3_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring_context_version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.validation</artifactId>
                 <version>${fhir.core.version}</version>
@@ -216,6 +230,18 @@
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-server</artifactId>
+                <version>${hapi.fhir.version}</version>
+                <exclusions>
+                    <!-- CVE-2025-7962" "org.eclipse.angus:smtp" -->
+                    <exclusion>
+                        <groupId>org.simplejavamail</groupId>
+                        <artifactId>core-module</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>hapi-fhir-jpaserver-base</artifactId>
                 <version>${hapi.fhir.version}</version>
                 <exclusions>
@@ -235,6 +261,10 @@
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
update vunerabilities

## Summary by Sourcery

Release version 4.0.11 and address scanned vulnerabilities by upgrading dependencies, adding exclusions, and updating configuration

Bug Fixes:
- Patch scanned vulnerabilities via dependency upgrades and exclusions

Enhancements:
- Add Commons Lang3 and Spring Context dependencies with appropriate exclusions

Build:
- Bump project version to 4.0.11 and upgrade core dependencies (Spring to 6.1.21, Commons Lang3 to 3.18.0, Apache POI to 5.4.0)
- Introduce version properties for spring-context and commons-lang3

Documentation:
- Update changelog for 4.0.11 release and vulnerability updates

Chores:
- Update application.yaml to rename FHIR UV extension and set IG version to 0.3.0-draft