### PR TITLE
Upgrade Tomcat to fix CVE-2025-55752

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ $RECYCLE.BIN/
 .idea/*.iml
 .idea/modules
 .idea/sonarlint
+.idea/copilot.data.*.xml
 *.iml
 *.ipr
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+Release 4.0.15
+
+- Upgrade Tomcat to fix [CVE-2025-55752](https://github.com/advisories/GHSA-wmwf-9ccg-fff5)
+
 2025/10/21 Release 4.0.14
 
 - Further MCP Server integration [#398](https://github.com/ahdis/matchbox/issues/398)

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
         <!-- Other dependencies we need -->
         <lombok_version>1.18.36</lombok_version>
-        <tomcat_embed_version>10.1.44</tomcat_embed_version>
+        <tomcat_embed_version>10.1.48</tomcat_embed_version>
         <postgresql_version>42.7.7</postgresql_version>
         <h2_version>2.3.232</h2_version>
         <jakarta_servlet_version>6.1.0</jakarta_servlet_version>


### PR DESCRIPTION
## Summary by Sourcery

Upgrade embedded Tomcat to version 10.1.48 to fix CVE-2025-55752 and document the release in the changelog.

Bug Fixes:
- Bump embedded Tomcat to 10.1.48 to address CVE-2025-55752.

Documentation:
- Add Release 4.0.15 entry to changelog noting Tomcat upgrade for security fix.