### PR TITLE
Fix CDA datatypes mapping

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2025 Release 4.0.16
+
+- adapt test and map for (440)
+
 2025/11/03 Release 4.0.15
 
 - Upgrade Tomcat to fix [CVE-2025-55752](https://github.com/advisories/GHSA-wmwf-9ccg-fff5)

--- a/matchbox-engine/src/test/java/ch/ahdis/matchbox/engine/tests/CdaToFhirTransformTests.java
+++ b/matchbox-engine/src/test/java/ch/ahdis/matchbox/engine/tests/CdaToFhirTransformTests.java
@@ -31,27 +31,23 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
 import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StructureMap;
-import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
-import java.util.spi.CalendarNameProvider;
 
 class CdaToFhirTransformTests {
 
@@ -173,6 +169,12 @@ class CdaToFhirTransformTests {
 		Composition composition = (Composition) resource.getEntryFirstRep().getResource();
 		assertNotNull(composition);
 		assertEquals("2022-03-30T11:24:26+01:00", composition.getDateElement().getValueAsString());
+		Patient patient = (Patient) resource.getEntry().stream()
+				.filter(e -> e.getResource() instanceof Patient)
+				.map(e -> e.getResource())
+				.findFirst()
+				.orElse(null);
+		assertEquals("058091", patient.getAddressFirstRep().getLine().getFirst().getExtension().getFirst().getValue().toString());
 	}
 
 	@Test

--- a/matchbox-engine/src/test/resources/cda/datatypes.map
+++ b/matchbox-engine/src/test/resources/cda/datatypes.map
@@ -198,18 +198,11 @@ group ADAddress(source src : AD, target tgt : Address) extends Any <<types>> {
     item.county as v -> tgt.district = (v.xmlText);
     item.city as v -> tgt.city = (v.xmlText);
     item.postalCode as v -> tgt.postalCode = (v.xmlText);
-    item.streetAddressLine as v -> tgt.line=(v.xmlText);
-    
-    item   -> tgt.line  as line then { 
-    item where src.censusTract.exists() then {
-      item.censusTract as v -> line.extension as ext1 then CensusTract(v, ext1) "line";
-    }"sfgfdsg";
-    } "CensusTract";
-
-    //share firstline "streetAddress";
-    //as streetAddress then{
-      //src.censusTract as v->tgt.line as line, line.extension as ext1 then CensusTract(v, ext1) "line";
-    //src.censusTract as v ->tgt.line as line, line.extension as ext1 then CensusTract(v, ext1) "line";
+    item.streetAddressLine as v -> tgt.line=(v.xmlText) as line then {
+      src.item as item2 then {
+        item2.censusTract as v -> line.extension as ext1 then CensusTract(v, ext1) "line";
+      } "innercensus";
+    } "item2";
     item.streetName as v -> tgt.line = (v.xmlText);
     item.houseNumber as v -> tgt.line = (v.xmlText);
   } "item";


### PR DESCRIPTION
Changes:
- Cleaned up duplicated censusTract mapping in datatypes.map
- Updated test to verify censusTract extension is properly mapped
- Added test assertion for patient address line extension value

Fixes #440

## Summary by Sourcery

Fix CDA datatype mappings by removing a duplicated censusTract entry, updating tests to assert both censusTract and patient address line extensions, and update the changelog for release 4.0.16

Bug Fixes:
- Remove duplicated censusTract mapping in datatypes.map
- Ensure censusTract extension is correctly mapped

Documentation:
- Bump changelog to 2025 Release 4.0.16 noting test and map adjustments for issue #440

Tests:
- Add assertion in TestInitial to verify patient address line extension value