### PR TITLE
unrestrict transport layer jackson for mcp

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2026 Release 4.0.17
+
+- unrestrict transport layer jackson for mcp (#455)
+
 2026/01/08 Release 4.0.16
 
 - adapt test and map for (#440)

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
@@ -15,6 +15,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class McpServerConfig {
 		return HttpServletStreamableServerTransportProvider.builder()
 				.disallowDelete(false)
 				.mcpEndpoint(SSE_MESSAGE_ENDPOINT)
-				.objectMapper(new ObjectMapper().configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))
+				.objectMapper(new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))
 				// .contextExtractor((serverRequest, context) -> context)
 				.build();
 	}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
@@ -61,7 +61,7 @@ public class McpServerConfig {
 		return HttpServletStreamableServerTransportProvider.builder()
 				.disallowDelete(false)
 				.mcpEndpoint(SSE_MESSAGE_ENDPOINT)
-				.objectMapper(new ObjectMapper())
+				.objectMapper(new ObjectMapper().configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))
 				// .contextExtractor((serverRequest, context) -> context)
 				.build();
 	}


### PR DESCRIPTION
Added .objectMapper() configuration to the MCP server to ignore unknown properties, ensuring compatibility with newer versions

.objectMapper(new ObjectMapper().configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))

## Summary by Sourcery

Bug Fixes:
- Prevent MCP server from failing on incoming messages that contain unknown JSON properties in the transport payload.