### PR TITLE
Fix forwarding of `anyExtensionsAllowed`/`extensionDomains` in the validator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,9 @@
+Unreleased Release 4.0.18
+
+- fix forwarding of `anyExtensionsAllowed`/`extensionDomains` in the validator (#464)
+
 2026/01/27 Release 4.0.17
+
 - fixed search params not being included in the call to the server (#453)
 - unrestrict transport layer jackson for mcp (#455)
 - memory error / security issue (#457)

--- a/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
+++ b/matchbox-engine/src/main/java/ch/ahdis/matchbox/engine/MatchboxEngine.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -1229,7 +1230,18 @@ public class MatchboxEngine extends ValidationEngine {
 		if (advisor != null) {
 			return ((ch.ahdis.matchbox.engine.ValidationPolicyAdvisor) advisor).getSuppressedErrorMessages();
 		}
-		return null;
+		return Collections.emptyList();
+	}
+
+	@Override
+	public InstanceValidator getValidator(final FhirFormat format) throws FHIRException, IOException {
+		final var validator = super.getValidator(format);
+		validator.setAnyExtensionsAllowed(this.isAnyExtensionsAllowed());
+		validator.getExtensionDomains().clear();
+		if (this.getExtensionDomains() != null) {
+			validator.getExtensionDomains().addAll(this.getExtensionDomains());
+		}
+		return validator;
 	}
 
 	/**

--- a/matchbox-engine/src/test/java/ch/ahdis/matchbox/engine/tests/R4ValidationTests.java
+++ b/matchbox-engine/src/test/java/ch/ahdis/matchbox/engine/tests/R4ValidationTests.java
@@ -4,10 +4,12 @@ import ch.ahdis.matchbox.engine.MatchboxEngine;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
-import org.hl7.fhir.utilities.FhirPublication;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,12 @@ class R4ValidationTests {
 		this.careplanRaw = this.loadSample("careplan.xml");
 		this.measureRaw = this.loadSample("measure.xml");
 		this.relatedPerson = this.loadSample("RelatedPerson-BiologicalFather.json");
+	}
+
+	@BeforeEach
+	void resetEngine() {
+		this.engine.setAnyExtensionsAllowed(false);
+		this.engine.setExtensionDomains(List.of());
 	}
 
 	/**
@@ -136,6 +144,44 @@ class R4ValidationTests {
 		//final String invalidObservation = observationRaw.replace("{{UNIT}}", "non-existent-code");
 		//final var errors = this.expectInvalid(invalidObservation, Manager.FhirFormat.XML, "http://hl7.org/fhir/StructureDefinition/Observation");
 		//assertEquals(1, errors.size());
+	}
+
+	/**
+	 * We validate a Patient resource with a CH Core extension that isn't known by the validator.
+	 * By default, this should be rejected (anyExtensionsAllowed = false and extensionDomains = []).
+	 */
+	@Test
+	void testUnknownExtensionIsRejectedByDefault() throws Exception {
+		final String resourceWithUnknownExtension = this.loadSample("patient-with-extension.json");
+		this.expectInvalid(resourceWithUnknownExtension, Manager.FhirFormat.JSON, "http://hl7" +
+			".org/fhir/StructureDefinition/Patient");
+	}
+
+	/**
+	 * The same Patient should be valid with anyExtensionsAllowed = true.
+	 */
+	@Test
+	void testUnknownExtensionCanBeAcceptedWithAny() throws Exception {
+		this.engine.setAnyExtensionsAllowed(true);
+		final String resourceWithUnknownExtension = this.loadSample("patient-with-extension.json");
+		this.expectValid(resourceWithUnknownExtension, Manager.FhirFormat.JSON, "http://hl7.org/fhir/StructureDefinition/Patient");
+	}
+
+	/**
+	 * The same Patient should be valid if we allow the specific domain of the extension.
+	 * We test different inputs for the domain: from the exact extension URL, to the DNS name only.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient-ech-11-placeoforigin",
+		"http://fhir.ch/ig/ch-core/",
+		"http://fhir.ch/",
+		"http://fhir.ch",
+	})
+	void testUnknownExtensionCanBeAcceptedWithDomain(final String allowedDomain) throws Exception {
+		this.engine.setExtensionDomains(List.of(allowedDomain));
+		final String resourceWithUnknownExtension = this.loadSample("patient-with-extension.json");
+		this.expectValid(resourceWithUnknownExtension, Manager.FhirFormat.JSON, "http://hl7.org/fhir/StructureDefinition/Patient");
 	}
 
 	/**

--- a/matchbox-engine/src/test/resources/r4-samples/patient-with-extension.json
+++ b/matchbox-engine/src/test/resources/r4-samples/patient-with-extension.json
@@ -1,0 +1,38 @@
+{
+  "resourceType" : "Patient",
+  "id" : "ManuelaMuster",
+  "extension" : [{
+      "url" : "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient-ech-11-placeoforigin",
+      "valueAddress" : {
+        "city" : "Köniz",
+        "state" : "BE"
+      }
+    }],
+  "identifier" : [{
+    "system" : "urn:oid:2.16.756.5.30.1.127.3.10.3",
+    "value" : "761337615317835750"
+  }],
+  "name" : [{
+    "family" : "Muster",
+    "given" : ["Manuela"]
+  }],
+  "gender" : "female",
+  "birthDate" : "1997-02-21",
+  "maritalStatus" : {
+    "coding" : [{
+      "system" : "http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus",
+      "code" : "6",
+      "display" : "in eingetragener Partnerschaft"
+    }]
+  },
+  "communication" : [{
+    "language" : {
+      "coding" : [{
+        "system" : "urn:ietf:bcp:47",
+        "code" : "de-CH"
+      }],
+      "text" : "Deutsch (Schweiz)"
+    },
+    "preferred" : true
+  }]
+}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/util/MatchboxEngineSupport.java
@@ -556,10 +556,8 @@ public class MatchboxEngineSupport {
 		validator.setDoNative(cli.isDoNative());
 		validator.setHintAboutNonMustSupport(cli.isHintAboutNonMustSupport());
 		validator.setAnyExtensionsAllowed(false);
-		if (cli.getExtensions() == null ) {
-			validator.setAnyExtensionsAllowed(false);
-		} else {
-			for (String s : cli.getExtensions()) {
+		if (cli.getExtensions() != null) {
+			for (final String s : cli.getExtensions()) {
 				if ("any".equals(s)) {
 					validator.setAnyExtensionsAllowed(true);
 				} else {	

--- a/matchbox-server/src/test/java/ch/ahdis/matchbox/test/MatchboxApiR4Test.java
+++ b/matchbox-server/src/test/java/ch/ahdis/matchbox/test/MatchboxApiR4Test.java
@@ -15,6 +15,7 @@ import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
 import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r4.model.Parameters;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -70,8 +71,7 @@ class MatchboxApiR4Test {
 				</text>
 			</Patient>""";
 
-		IBaseOperationOutcome operationOutcome = this.validationClient.validate(patient,
-																										"http://hl7.org/fhir/StructureDefinition/Patient");
+		IBaseOperationOutcome operationOutcome = this.validationClient.validate(patient, profileCore("Patient"));
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
 
 		String sessionIdFirst = getSessionId(operationOutcome);
@@ -95,7 +95,7 @@ class MatchboxApiR4Test {
 			</Practitioner>""";
 
 		// tests against base core profile
-		String profileCore = "http://hl7.org/fhir/StructureDefinition/Practitioner";
+		String profileCore = profileCore("Practitioner");
 		IBaseOperationOutcome operationOutcome = validationClient.validate(resource, profileCore);
 		String sessionIdCore = getSessionId(operationOutcome);
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
@@ -239,7 +239,7 @@ class MatchboxApiR4Test {
 		// validationClient.validate(getContent("ehs-431.json"),
 		// "http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-document-medicationcard");
 		IBaseOperationOutcome operationOutcome = validationClient.validate(getContent("ehs-431.json"),
-																								 "http://hl7.org/fhir/StructureDefinition/Bundle");
+																								 profileCore("Bundle"));
 		log.debug(FHIR_CONTEXT.newJsonParser().encodeResourceToString(operationOutcome));
 		assertEquals(1, getValidationFailures((OperationOutcome) operationOutcome));
 	}
@@ -247,7 +247,7 @@ class MatchboxApiR4Test {
 	@Test
 	void validateEhs431Gazelle() throws Exception {
 		ValidationReport report = this.validateWithGazelle(getContent("ehs-431.json"),
-																			"http://hl7.org/fhir/StructureDefinition/Bundle");
+																			profileCore("Bundle"));
 		assertEquals(1, getValidationFailures(report));
 	}
 
@@ -255,7 +255,7 @@ class MatchboxApiR4Test {
 		// https://gazelle.ihe.net/jira/browse/EHS-419
 	void validateEhs419() throws IOException {
 		IBaseOperationOutcome operationOutcome = validationClient.validate(getContent("ehs-419.json"),
-																								 "http://hl7.org/fhir/StructureDefinition/Patient");
+																								 profileCore("Patient"));
 		log.debug(FHIR_CONTEXT.newJsonParser().encodeResourceToString(operationOutcome));
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
 	}
@@ -282,7 +282,7 @@ class MatchboxApiR4Test {
 						"</RelatedPerson>";
 
 		IBaseOperationOutcome operationOutcome = this.validationClient.validate(patient,
-																										"http://hl7.org/fhir/StructureDefinition/RelatedPerson");
+																										profileCore("RelatedPerson"));
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
 	}
 
@@ -349,6 +349,45 @@ class MatchboxApiR4Test {
 		IBaseOperationOutcome operationOutcome = this.validationClient.validate(encounter,
 																			"http://matchbox.health/ig/test/r4/StructureDefinition/encounter-ext-r5");
 		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
+	}
+
+	@Test
+	@Disabled("For some reason, the validation engine does not fail on unknown extensions with the default configuration, needs further investigation")
+	void validateUnknownExtensionIsRejectedByDefault() throws Exception {
+		final var patient = getContent("patient-dicom.json");
+		final var operationOutcome = this.validationClient.validate(patient, profileCore("Patient"));
+		assertEquals(1, getValidationFailures((OperationOutcome) operationOutcome));
+	}
+
+	@Test
+	void validateUnknownExtensionIsAcceptedWithAny() throws Exception {
+		final var patient = getContent("patient-dicom.json");
+		final var parameters = new Parameters();
+		parameters.addParameter("extensions", "any");
+
+		final var operationOutcome = this.validationClient.validate(patient, profileCore("Patient"), parameters);
+		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
+	}
+
+	@Test
+	void validateUnknownExtensionIsAcceptedWithValidDomain() throws Exception {
+		final var patient = getContent("patient-dicom.json");
+		final var parameters = new Parameters();
+		parameters.addParameter("extensions", "http://nema.org");
+
+		final var operationOutcome = this.validationClient.validate(patient, profileCore("Patient"), parameters);
+		assertEquals(0, getValidationFailures((OperationOutcome) operationOutcome));
+	}
+
+	@Test
+	@Disabled("For some reason, the validation engine does not fail on unknown extensions with the default configuration, needs further investigation")
+	void validateUnknownExtensionIsRejectedWithWrongDomain() throws Exception {
+		final var patient = getContent("patient-dicom.json");
+		final var parameters = new Parameters();
+		parameters.addParameter("extensions", "http://fhir.ch");
+
+		final var operationOutcome = this.validationClient.validate(patient, profileCore("Patient"), parameters);
+		assertEquals(1, getValidationFailures((OperationOutcome) operationOutcome));
 	}
 
 
@@ -472,5 +511,9 @@ class MatchboxApiR4Test {
 
 	private static int getValidationFailures(final ValidationReport report) {
 		return report.getCounters().getNumberOfFailedWithErrors() + report.getCounters().getNumberOfUnexpectedErrors();
+	}
+
+	private static String profileCore(final String resourceName) {
+		return "http://hl7.org/fhir/StructureDefinition/" + resourceName;
 	}
 }

--- a/matchbox-server/src/test/resources/patient-dicom.json
+++ b/matchbox-server/src/test/resources/patient-dicom.json
@@ -1,0 +1,58 @@
+{
+  "resourceType": "Patient",
+  "id": "dicom",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"> Patient MINT_TEST, ID = MINT1234. Age = 56y, Size =\n      1.83m, Weight = 72.58kg </div>"
+  },
+  "extension": [
+    {
+      "url": "http://nema.org/fhir/extensions#0010:1010",
+      "valueQuantity": {
+        "value": 56,
+        "unit": "Y"
+      }
+    },
+    {
+      "url": "http://nema.org/fhir/extensions#0010:1020",
+      "valueQuantity": {
+        "value": 1.83,
+        "unit": "m"
+      }
+    },
+    {
+      "url": "http://nema.org/fhir/extensions#0010:1030",
+      "valueQuantity": {
+        "value": 72.58,
+        "unit": "kg"
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://nema.org/examples/patients",
+      "value": "MINT1234"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "MINT_TEST"
+    }
+  ],
+  "gender": "male",
+  "_gender": {
+    "extension": [
+      {
+        "url": "http://nema.org/examples/extensions#gender",
+        "valueCoding": {
+          "system": "http://nema.org/examples/gender",
+          "code": "M"
+        }
+      }
+    ]
+  },
+  "managingOrganization": {
+    "reference": "Organization/1"
+  }
+}


### PR DESCRIPTION
Fixes #464, but there are obscure things going on:

- Why does `ValidationEngine` has a `anyExtensionsAllowed` member but isn't used anywhere?
- Why does `ValidationEngine.validate()` has a `anyExtensionsAllowed` parameter that is also unused?
- Why doesn't `MatchboxApiR4Test` reject unknown extensions, as `R4ValidationTests` does?

## Summary by Sourcery

Ensure validator respects configuration for unknown extensions and add regression coverage.

Bug Fixes:
- Forward anyExtensionsAllowed and extensionDomains settings from MatchboxEngine to the underlying InstanceValidator so extension validation behaves as configured.

Enhancements:
- Reset extension-related configuration before each R4 validation test and return an empty list instead of null for suppressed error messages.

Documentation:
- Document the fix to extension validation forwarding in the changelog for the upcoming 4.0.18 release.

Tests:
- Add engine-level tests verifying default rejection and configurable acceptance of unknown extensions via anyExtensionsAllowed and extensionDomains.
- Add server-level API tests for validating behavior with default, any, and domain-specific extension settings, including disabled cases pending further investigation.