### PR TITLE
WIP: Statistics

### DIFF
--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
@@ -1,10 +1,10 @@
 package ca.uhn.fhir.jpa.dao.data;
 
-import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionResourceEntity;
+import ca.uhn.fhir.jpa.model.entity.StatisticsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IStatisticsDao extends JpaRepository<NpmPackageVersionResourceEntity, Long>, IHapiFhirJpaRepository {
+public interface IStatisticsDao extends JpaRepository<StatisticsEntity, Long>, IHapiFhirJpaRepository {
   
 }

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
@@ -1,0 +1,10 @@
+package ca.uhn.fhir.jpa.dao.data;
+
+import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionResourceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IStatisticsDao extends JpaRepository<NpmPackageVersionResourceEntity, Long>, IHapiFhirJpaRepository {
+  
+}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
@@ -1,10 +1,12 @@
 package ca.uhn.fhir.jpa.dao.data;
 
 import ca.uhn.fhir.jpa.model.entity.StatisticsEntity;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@ConditionalOnProperty(prefix = "matchbox.validation", name = "save-statistics", havingValue = "true")
 public interface IStatisticsDao extends JpaRepository<StatisticsEntity, Long>, IHapiFhirJpaRepository {
   
 }

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/dao/data/IStatisticsDao.java
@@ -3,10 +3,17 @@ package ca.uhn.fhir.jpa.dao.data;
 import ca.uhn.fhir.jpa.model.entity.StatisticsEntity;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
 
 @Repository
 @ConditionalOnProperty(prefix = "matchbox.validation", name = "save-statistics", havingValue = "true")
-public interface IStatisticsDao extends JpaRepository<StatisticsEntity, Long>, IHapiFhirJpaRepository {
+public interface IStatisticsDao extends JpaRepository<StatisticsEntity, Long>, IHapiFhirJpaRepository { 
   
+  @Query("SELECT e FROM StatisticsEntity e WHERE e.timestamp >= :from AND e.timestamp <= :to")
+  List<StatisticsEntity> searchByDate(@Param("from") Instant from, @Param("to") Instant to);
 }

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
@@ -1,0 +1,63 @@
+package ca.uhn.fhir.jpa.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "MATCHBOX_STATISTICS")
+public class StatisticsEntity {
+  
+  @Getter
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+  
+  @Setter
+  @Getter
+  @Column(name = "PROFILE_URL", length = 255, nullable = false)
+  private String profile;
+
+  @Setter
+  @Getter
+  @Column(name = "PACKAGES", length = 16535, nullable = false)
+  private String packages;
+
+  @Setter
+  @Getter
+  @Column(name = "NUMBER_OF_INFORMATIONS", nullable = false)
+  private Integer numberOfInfos;
+
+  @Setter
+  @Getter
+  @Column(name = "NUMBER_OF_WARNINGS", nullable = false)
+  private Integer numberOfWarnings;
+
+  @Setter
+  @Getter
+  @Column(name = "NUMBER_OF_ERRORS", nullable = false)
+  private Integer numberOfErrors;
+
+  @Setter
+  @Getter
+  @Column(name = "NUMBER_OF_FATALS", nullable = false)
+  private Integer numberOfFatals;
+
+  @Setter
+  @Getter
+  @Column(name = "TIMESTAMP", nullable = false)
+  private LocalDateTime timestamp;
+
+  @Setter
+  @Getter
+  @Column(name = "DURATION", nullable = false)
+  private Long durationMillis;
+
+  @Setter
+  @Getter
+  @Column(name = "AI_USED", nullable = false)
+  private Boolean aiUsed;
+
+}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -48,7 +49,8 @@ public class StatisticsEntity {
   @Setter
   @Getter
   @Column(name = "TIMESTAMP", nullable = false)
-  private LocalDateTime timestamp;
+  @Temporal(TemporalType.TIMESTAMP)
+  private Instant timestamp;
 
   @Setter
   @Getter

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
@@ -59,5 +59,10 @@ public class StatisticsEntity {
   @Getter
   @Column(name = "AI_USED", nullable = false)
   private Boolean aiUsed;
+  
+  @Setter
+  @Getter
+  @Column(name = "SUCCESS", nullable = false)
+  private Boolean success;
 
 }

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/model/entity/StatisticsEntity.java
@@ -28,22 +28,22 @@ public class StatisticsEntity {
 
   @Setter
   @Getter
-  @Column(name = "NUMBER_OF_INFORMATIONS", nullable = false)
+  @Column(name = "NUMBER_OF_INFORMATIONS", nullable = false, columnDefinition = "TINYINT UNSIGNED")
   private Integer numberOfInfos;
 
   @Setter
   @Getter
-  @Column(name = "NUMBER_OF_WARNINGS", nullable = false)
+  @Column(name = "NUMBER_OF_WARNINGS", nullable = false, columnDefinition = "TINYINT UNSIGNED")
   private Integer numberOfWarnings;
 
   @Setter
   @Getter
-  @Column(name = "NUMBER_OF_ERRORS", nullable = false)
+  @Column(name = "NUMBER_OF_ERRORS", nullable = false, columnDefinition = "TINYINT UNSIGNED")
   private Integer numberOfErrors;
 
   @Setter
   @Getter
-  @Column(name = "NUMBER_OF_FATALS", nullable = false)
+  @Column(name = "NUMBER_OF_FATALS", nullable = false, columnDefinition = "TINYINT UNSIGNED")
   private Integer numberOfFatals;
 
   @Setter
@@ -54,7 +54,7 @@ public class StatisticsEntity {
 
   @Setter
   @Getter
-  @Column(name = "DURATION", nullable = false)
+  @Column(name = "DURATION", nullable = false, columnDefinition = "INT UNSIGNED")
   private Long durationMillis;
 
   @Setter

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigR4.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigR4.java
@@ -1,9 +1,11 @@
 package ca.uhn.fhir.jpa.starter.common;
 
+import ca.uhn.fhir.jpa.dao.data.IStatisticsDao;
 import ch.ahdis.matchbox.mappinglanguage.StructureMapListProvider;
 import ch.ahdis.matchbox.providers.ValueSetResourceProvider;
 import ch.ahdis.matchbox.providers.ConceptMapResourceProvider;
 import ch.ahdis.matchbox.packages.ImplementationGuideProviderR4;
+import ch.ahdis.matchbox.statistics.StatisticsObservationProvider;
 import ch.ahdis.matchbox.util.MatchboxEngineSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -61,6 +63,11 @@ public class FhirServerConfigR4 {
   @Bean
   public ValidationProvider validationProvider() {
     return new ValidationProvider();
+  }
+  
+  @Bean
+  public StatisticsObservationProvider statisticsObservationProvider(IStatisticsDao statisticsDao) { 
+    return new StatisticsObservationProvider(statisticsDao);
   }
 
 

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
@@ -13,6 +13,7 @@ import ch.ahdis.matchbox.mappinglanguage.StructureMapListProvider;
 import ch.ahdis.matchbox.packages.*;
 import ch.ahdis.matchbox.providers.*;
 import ch.ahdis.matchbox.questionnaire.*;
+import ch.ahdis.matchbox.statistics.StatisticsObservationProvider;
 import ch.ahdis.matchbox.util.MatchboxEngineSupport;
 import ch.ahdis.matchbox.util.MatchboxPackageInstallerImpl;
 import jakarta.persistence.EntityManager;
@@ -154,6 +155,9 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 	@Autowired(required = false)
 	private ImplementationGuideProviderR5 implementationGuideResourceProviderR5;
 
+	@Autowired
+	private StatisticsObservationProvider statisticsObservationProvider;
+
 	// removed GraphQlProvider
 	// removed IVAldiationSupport
 	
@@ -199,7 +203,8 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 			this.valueSetProvider,
 			this.structureDefinitionProvider,
 			this.structureMapTransformProvider,
-			this.structureMapListProvider
+			this.structureMapListProvider,
+			this.statisticsObservationProvider
 		})
 		.filter(Objects::nonNull)
 		.forEach(fhirServer::registerProvider);

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/statistics/StatisticsObservationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/statistics/StatisticsObservationProvider.java
@@ -1,0 +1,96 @@
+package ch.ahdis.matchbox.statistics;
+
+import ca.uhn.fhir.jpa.dao.data.IStatisticsDao;
+import ca.uhn.fhir.jpa.model.entity.StatisticsEntity;
+import ca.uhn.fhir.rest.annotation.RequiredParam;
+import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class StatisticsObservationProvider implements IResourceProvider {
+
+	private final IStatisticsDao statisticsDao;
+
+	public StatisticsObservationProvider(final IStatisticsDao statisticsDao) {
+		this.statisticsDao = statisticsDao;
+	}
+
+	// GET /fhir/Observation?date=lt2027&date=gt2025
+	// https://hl7.org/fhir/R4/search.html#date
+	@Search
+	@Transactional
+	public List<Observation> searchStatistics(@RequiredParam(name = "date") final DateRangeParam dateRange) {
+		try {
+			return this.searchObservations(dateRange);
+		} catch (final Exception e) {
+			OperationOutcome operationOutcome = new OperationOutcome();
+			operationOutcome.addIssue()
+				.setSeverity(OperationOutcome.IssueSeverity.ERROR)
+				.setCode(OperationOutcome.IssueType.EXCEPTION)
+				.setDiagnostics(e.getMessage());
+
+			throw new InternalErrorException("message", operationOutcome);
+
+		}
+	}
+
+
+	private List<Observation> searchObservations(final DateRangeParam dateRange) {
+		// initialize from and to variables with default values
+		Instant from = Instant.parse("2000-01-01T00:00:00Z");
+		Instant to = Instant.now();
+
+		// assign lower and upper bounds if they exist
+		if (dateRange.getLowerBoundAsInstant() != null) {
+			from = dateRange.getLowerBoundAsInstant().toInstant();
+		}
+		if (dateRange.getUpperBoundAsInstant() != null) {
+			to = dateRange.getUpperBoundAsInstant().toInstant();
+		}
+
+		// use searchByDate function in IStatisticsDao
+		List<StatisticsEntity> filteredStatistics = this.statisticsDao.searchByDate(from, to);
+
+		// initialize Observation list
+		List<Observation> observations = new ArrayList<>();
+
+		// map each entity to an observation and add to observation list
+		for (StatisticsEntity entity : filteredStatistics) {
+			Observation observation = new Observation();
+			observation.setId(UUID.randomUUID().toString());
+
+			observation.setCode(new CodeableConcept().setText("Validation statistic"));
+			observation.setEffective(new InstantType(Date.from(entity.getTimestamp())));
+			observation.setStatus(Observation.ObservationStatus.FINAL);
+
+			observation.addComponent()
+					.setCode(new CodeableConcept().setText("Success"))
+					.setValue(new BooleanType(entity.getSuccess()));
+
+
+
+			observations.add(observation);
+		}
+		// map to Observation: to be discussed
+
+
+		// return observation list
+		return observations;
+	}
+
+	public Class<? extends IBaseResource> getResourceType() {
+		return Observation.class;
+	}
+}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -104,7 +104,8 @@ public class ValidationProvider {
 	@Autowired
 	private PlatformTransactionManager myTxManager;
 
-	@Autowired
+	@Autowired(required = false)
+	@Nullable
 	private IStatisticsDao statisticsDao;
 
 //	@Operation(name = "$canonical", manualRequest = true, idempotent = true, returnParameters = {
@@ -275,12 +276,13 @@ public class ValidationProvider {
 			}
 		}
 
-		try {
-			this.saveStatistics(oo, profile, millis, aiUsed, engine);
-		} catch (Exception e) {
-			log.error("Error while saving statistics: ", e);
+		if (this.statisticsDao != null) {
+			try {
+				this.saveStatistics(oo, profile, millis, aiUsed, engine);
+			} catch (Exception e) {
+				log.error("Error while saving statistics: ", e);
+			}
 		}
-
 		
 		return switch (this.myContext.getVersion().getVersion()) {
 			case R4 -> VersionConvertorFactory_40_50.convertResource((OperationOutcome) oo);

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -275,7 +275,7 @@ public class ValidationProvider {
 		}
 
 		try {
-			this.saveStatistics(oo, profile, millis, aiUsed);
+			this.saveStatistics(oo, profile, millis, aiUsed, engine);
 		} catch (Exception e) {
 			log.error("Error while saving statistics: ", e);
 		}
@@ -464,14 +464,16 @@ public class ValidationProvider {
 	}
 
 	/**
-	 * This method extracts Statistics (Errorcount, packages used, ...) from the current OO. These then get stored in the
-	 * database together with the profile, duration and aiUsed attribute.
+	 * This method extracts Statistics (Error count, packages used, ...) from the current OO. These then get stored in
+	 * the database together with the profile, duration and aiUsed attribute.
 	 * @param oo Current OperationOutcome response; used to extract statistics
 	 * @param profile Current FHIR profile selected
 	 * @param duration Amount of milliseconds the validation took
 	 * @param aiUsed States if AI analysis was used
+	 * @param engine Takes the used Matchboxengine to extract the loaded packages.
 	 */
-	public void saveStatistics(OperationOutcome oo, String profile, Long duration, boolean aiUsed) {
+	public void saveStatistics(OperationOutcome oo, String profile, Long duration,
+										boolean aiUsed, MatchboxEngine engine) {
 		// create new Statistics Entity (new row in table)
 		final var statsEntity = new StatisticsEntity();
 
@@ -499,18 +501,8 @@ public class ValidationProvider {
 			validationSuccess = true;
 		}
 
-		// extract all packages and store them in a list
-		List<String> usedPackagesList = new ArrayList<>();
-		if (!oo.getIssue().isEmpty()) {
-			var matchboxExtensionIssue = oo.getIssue().getFirst().getExtensionByUrl("http://matchbox.health/validation");
-			for (var ext : matchboxExtensionIssue.getExtension()) {
-				if ("package".equals(ext.getUrl()) && ext.hasValue()) {
-					usedPackagesList.add(ext.getValue().toString());
-				}
-			}
-		}
-		// convert the list into a single string divided by ", "
-		String usedPackagesString = String.join(", ", usedPackagesList);
+		// extract all packages from the Matchbox engine and join them in a String
+		final String usedPackagesString = String.join(",", engine.getContext().getLoadedPackages());
 
 		// set all the fields with the corresponding parameters
 		statsEntity.setProfile(profile);

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -72,6 +72,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -485,7 +486,7 @@ public class ValidationProvider {
 		boolean validationSuccess = false;
 
 		// get the current timestamp to save in the database
-		LocalDateTime timestamp = LocalDateTime.now();
+		Instant timestamp = Instant.now();
 
 		// iterate through every issue in the OO and update the severity count
 		for (var issue : oo.getIssue()) {

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -242,7 +242,7 @@ public class ValidationProvider {
 
 		var oo = this.getOperationOutcome(sha3Hex, messages, profile, engine, millis, cliContext);
 
-		Boolean aiUsed = false;
+		boolean aiUsed = false;
 
 		Boolean aiAnalyze = null;
 		// check if the request ai analyze parameter is set to true or false
@@ -275,6 +275,7 @@ public class ValidationProvider {
 			}
 		}
 
+		// here should also be an if Statement, if statistics are enabled in the configuration.
 		this.saveStatistics(oo, profile, millis, aiUsed);
 		
 		return switch (this.myContext.getVersion().getVersion()) {
@@ -459,16 +460,29 @@ public class ValidationProvider {
 		throw new IllegalArgumentException("Provided resource is not an OperationOutcome.");
 	}
 
-	public void saveStatistics(OperationOutcome oo, String profile, Long duration, Boolean aiUsed) {
+	/**
+	 * This method extracts Statistics (Errorcount, packages used, ...) from the current OO. These then get stored in the
+	 * database together with the profile, duration and aiUsed attribute.
+	 * @param oo Current OperationOutcome response; used to extract statistics
+	 * @param profile Current FHIR profile selected
+	 * @param duration Amount of milliseconds the validation took
+	 * @param aiUsed States if AI analysis was used
+	 */
+	public void saveStatistics(OperationOutcome oo, String profile, Long duration, boolean aiUsed) {
+		// create new Statistics Entity (new row in table)
 		StatisticsEntity statsEntity = new StatisticsEntity();
 
+		// initialize all the helper variables
 		int nbFatals = 0;
 		int nbErrors = 0;
 		int nbWarnings = 0;
 		int nbInfos = 0;
-		Boolean validationSuccess = false;
+		boolean validationSuccess = false;
+
+		// get the current timestamp to save in the database
 		LocalDateTime timestamp = LocalDateTime.now();
 
+		// iterate through every issue in the OO and update the severity count
 		for (var issue : oo.getIssue()) {
 			switch (issue.getSeverity()) {
 				case FATAL -> nbFatals++;
@@ -477,10 +491,12 @@ public class ValidationProvider {
 				case INFORMATION -> nbInfos++;
 			}
 		}
+		// check if the validation was flagged as successful
 		if (nbFatals == 0 && nbErrors == 0) {
 			validationSuccess = true;
 		}
 
+		// extract all packages and store them in a list
 		List<String> usedPackagesList = new ArrayList<>();
 		if (!oo.getIssue().isEmpty()) {
 			var matchboxExtensionIssue = oo.getIssue().getFirst().getExtensionByUrl("http://matchbox.health/validation");
@@ -490,8 +506,10 @@ public class ValidationProvider {
 				}
 			}
 		}
+		// convert the list into a single string divided by ", "
 		String usedPackagesString = String.join(", ", usedPackagesList);
 
+		// set all the fields with the corresponding parameters
 		statsEntity.setProfile(profile);
 		statsEntity.setPackages(usedPackagesString);
 		statsEntity.setNumberOfInfos(nbInfos);
@@ -501,17 +519,10 @@ public class ValidationProvider {
 		statsEntity.setTimestamp(timestamp);
 		statsEntity.setDurationMillis(duration);
 		statsEntity.setAiUsed(aiUsed);
+		statsEntity.setSuccess(validationSuccess);
 
-//		System.out.println("LOG OperationOutcome");
-//		System.out.println("Profile: " + profile);
-//		System.out.println("ValidationSuccess: " + validationSuccess);
-//		System.out.println("nbFatals: " + nbFatals);
-//		System.out.println("nbErrors: " + nbErrors);
-//		System.out.println("nbWarnings: " + nbWarnings);
-//		System.out.println("nbInfos: " + nbInfos);
-//		System.out.println("AIused: " + aiUsed);
-//		System.out.println("Millis: " + duration);
-//		System.out.println("UsedPackages: " + usedPackagesString);
+		// save to the database
+		this.statisticsDao.save(statsEntity);
 
 	}
 }

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -22,6 +22,8 @@ package ch.ahdis.matchbox.validation;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionResourceDao;
+import ca.uhn.fhir.jpa.dao.data.IStatisticsDao;
+import ca.uhn.fhir.jpa.model.entity.StatisticsEntity;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.api.EncodingEnum;
@@ -36,6 +38,7 @@ import ch.ahdis.matchbox.packages.MatchboxImplementationGuideProvider;
 import ch.ahdis.matchbox.registry.SimplifierPackage;
 import ch.ahdis.matchbox.registry.SimplifierPackageVersionsObject;
 import com.google.gson.Gson;
+import net.sf.saxon.functions.ConstantFunction;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.client.methods.HttpGet;
@@ -70,6 +73,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -99,6 +103,9 @@ public class ValidationProvider {
 
 	@Autowired
 	private PlatformTransactionManager myTxManager;
+
+	@Autowired
+	private IStatisticsDao statisticsDao;
 
 //	@Operation(name = "$canonical", manualRequest = true, idempotent = true, returnParameters = {
 //			@OperationParam(name = "return", type = IBase.class, min = 1, max = 1) })
@@ -235,6 +242,8 @@ public class ValidationProvider {
 
 		var oo = this.getOperationOutcome(sha3Hex, messages, profile, engine, millis, cliContext);
 
+		Boolean aiUsed = false;
+
 		Boolean aiAnalyze = null;
 		// check if the request ai analyze parameter is set to true or false
 		if (theRequest.getParameter("analyzeOutcomeWithAI") != null) {
@@ -258,6 +267,7 @@ public class ValidationProvider {
 				String json = FhirContext.forR5Cached().newJsonParser().encodeResourceToString(oo);
 				String aiResult = openAIConnector.interpretWithMatchbox(contentString, json);
 				oo = this.addAIIssueToOperationOutcome(oo, aiResult);
+				aiUsed = true;
 			} catch (Exception e) {
 				log.error("Error during AI analysis", e);
 				// add the error to the OperationOutcome, so the client still gets the validation result
@@ -265,6 +275,7 @@ public class ValidationProvider {
 			}
 		}
 
+		this.saveStatistics(oo, profile, millis, aiUsed);
 		
 		return switch (this.myContext.getVersion().getVersion()) {
 			case R4 -> VersionConvertorFactory_40_50.convertResource((OperationOutcome) oo);
@@ -275,7 +286,7 @@ public class ValidationProvider {
 		};
 	}
 
-	private IBaseResource getOperationOutcome(final String id,
+	private OperationOutcome getOperationOutcome(final String id,
 															final List<ValidationMessage> messages,
 															final String profile,
 															final MatchboxEngine engine,
@@ -418,7 +429,7 @@ public class ValidationProvider {
 		return messages;
 	}
 
-	public IBaseResource addAIIssueToOperationOutcome(IBaseResource resource, String aiResponse) {
+	public OperationOutcome addAIIssueToOperationOutcome(IBaseResource resource, String aiResponse) {
 		if (resource instanceof final OperationOutcome outcome) {
 			final var details = new CodeableConcept();
 			details.setText("AI Analyze of the Operation Outcome");
@@ -437,7 +448,7 @@ public class ValidationProvider {
 		throw new IllegalArgumentException("Provided resource is not an OperationOutcome.");
 	}
 
-	public IBaseResource addExceptionToOperationOutcome(IBaseResource resource, Exception e) {
+	public OperationOutcome addExceptionToOperationOutcome(IBaseResource resource, Exception e) {
 		if (resource instanceof final OperationOutcome outcome) {
 			outcome.addIssue()
 				.setSeverity(OperationOutcome.IssueSeverity.ERROR)
@@ -447,4 +458,61 @@ public class ValidationProvider {
 		}
 		throw new IllegalArgumentException("Provided resource is not an OperationOutcome.");
 	}
+
+	public void saveStatistics(OperationOutcome oo, String profile, Long duration, Boolean aiUsed) {
+		StatisticsEntity statsEntity = new StatisticsEntity();
+
+		int nbFatals = 0;
+		int nbErrors = 0;
+		int nbWarnings = 0;
+		int nbInfos = 0;
+		Boolean validationSuccess = false;
+		LocalDateTime timestamp = LocalDateTime.now();
+
+		for (var issue : oo.getIssue()) {
+			switch (issue.getSeverity()) {
+				case FATAL -> nbFatals++;
+				case ERROR -> nbErrors++;
+				case WARNING -> nbWarnings++;
+				case INFORMATION -> nbInfos++;
+			}
+		}
+		if (nbFatals == 0 && nbErrors == 0) {
+			validationSuccess = true;
+		}
+
+		List<String> usedPackagesList = new ArrayList<>();
+		if (!oo.getIssue().isEmpty()) {
+			var matchboxExtensionIssue = oo.getIssue().getFirst().getExtensionByUrl("http://matchbox.health/validation");
+			for (var ext : matchboxExtensionIssue.getExtension()) {
+				if ("package".equals(ext.getUrl()) && ext.hasValue()) {
+					usedPackagesList.add(ext.getValue().toString());
+				}
+			}
+		}
+		String usedPackagesString = String.join(", ", usedPackagesList);
+
+		statsEntity.setProfile(profile);
+		statsEntity.setPackages(usedPackagesString);
+		statsEntity.setNumberOfInfos(nbInfos);
+		statsEntity.setNumberOfWarnings(nbWarnings);
+		statsEntity.setNumberOfErrors(nbErrors);
+		statsEntity.setNumberOfFatals(nbFatals);
+		statsEntity.setTimestamp(timestamp);
+		statsEntity.setDurationMillis(duration);
+		statsEntity.setAiUsed(aiUsed);
+
+//		System.out.println("LOG OperationOutcome");
+//		System.out.println("Profile: " + profile);
+//		System.out.println("ValidationSuccess: " + validationSuccess);
+//		System.out.println("nbFatals: " + nbFatals);
+//		System.out.println("nbErrors: " + nbErrors);
+//		System.out.println("nbWarnings: " + nbWarnings);
+//		System.out.println("nbInfos: " + nbInfos);
+//		System.out.println("AIused: " + aiUsed);
+//		System.out.println("Millis: " + duration);
+//		System.out.println("UsedPackages: " + usedPackagesString);
+
+	}
 }
+

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/validation/ValidationProvider.java
@@ -38,7 +38,6 @@ import ch.ahdis.matchbox.packages.MatchboxImplementationGuideProvider;
 import ch.ahdis.matchbox.registry.SimplifierPackage;
 import ch.ahdis.matchbox.registry.SimplifierPackageVersionsObject;
 import com.google.gson.Gson;
-import net.sf.saxon.functions.ConstantFunction;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.client.methods.HttpGet;
@@ -275,8 +274,12 @@ public class ValidationProvider {
 			}
 		}
 
-		// here should also be an if Statement, if statistics are enabled in the configuration.
-		this.saveStatistics(oo, profile, millis, aiUsed);
+		try {
+			this.saveStatistics(oo, profile, millis, aiUsed);
+		} catch (Exception e) {
+			log.error("Error while saving statistics: ", e);
+		}
+
 		
 		return switch (this.myContext.getVersion().getVersion()) {
 			case R4 -> VersionConvertorFactory_40_50.convertResource((OperationOutcome) oo);
@@ -470,7 +473,7 @@ public class ValidationProvider {
 	 */
 	public void saveStatistics(OperationOutcome oo, String profile, Long duration, boolean aiUsed) {
 		// create new Statistics Entity (new row in table)
-		StatisticsEntity statsEntity = new StatisticsEntity();
+		final var statsEntity = new StatisticsEntity();
 
 		// initialize all the helper variables
 		int nbFatals = 0;

--- a/matchbox-server/src/main/resources/application.yaml
+++ b/matchbox-server/src/main/resources/application.yaml
@@ -92,6 +92,8 @@ matchbox:
       suppressWarnInfo:
         hl7.fhir.r4.core#4.0.1:
           #- "Constraint failed: dom-6:"
+  validation:
+    save-statistics: false
 logging:
   config: classpath:logback.xml # This is needed, otherwise Logback will load logback-test.xml in priority
   level:

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
 
         <!-- Other dependencies we need -->
-        <lombok_version>1.18.36</lombok_version>
+        <lombok_version>1.18.42</lombok_version>
         <tomcat_embed_version>10.1.48</tomcat_embed_version>
         <postgresql_version>42.7.7</postgresql_version>
         <h2_version>2.3.232</h2_version>


### PR DESCRIPTION
## Summary by Sourcery

Collect and persist validation statistics for each OperationOutcome, including AI usage metadata, and prepare the validation workflow to support statistics recording.

New Features:
- Add a statistics persistence flow that extracts counts, packages, timing, and success state from OperationOutcome responses and stores them via a new JPA entity.
- Introduce a new database-backed StatisticsEntity and corresponding Spring Data repository for recording validation run metrics.

Enhancements:
- Adjust validation handling to track whether AI-based analysis was used and to work directly with OperationOutcome where appropriate.
- Update the Lombok dependency version in the build configuration.