### PR TITLE
Upgrade HAPI FHIR from 8.0.0 to 8.8.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2026/03/23 Release 4.1.0
+
+- Upgrade HAPI FHIR from 8.0.0 to 8.8.0, Spring Boot from 3.3.13 to 3.5.9
+
 2026/03/22 Release 4.0.20
 
 - FHIRPath Slicing cannot be evaluated (#487) temporary workaround

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.20</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.0.20</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -240,6 +240,8 @@ public class JpaConfig {
 	public static final String PERSISTED_JPA_SEARCH_FIRST_PAGE_BUNDLE_PROVIDER =
 			"PersistedJpaSearchFirstPageBundleProvider";
 	public static final String HISTORY_BUILDER = "HistoryBuilder";
+	public static final String PERSISTED_JPA_ID_SEARCH_BUNDLE_PROVIDER = "PersistedJpaIdSearchBundleProvider";
+	public static final String HISTORY_BUILDER_WITH_IDS = "HistoryBuilderWithIds";
 	public static final String DEFAULT_PROFILE_VALIDATION_SUPPORT = "myDefaultProfileValidationSupport";
 	private static final String HAPI_DEFAULT_SCHEDULER_GROUP = "HAPI";
 
@@ -249,10 +251,20 @@ public class JpaConfig {
 	@Autowired
 	private FhirContext myFhirContext;
 
+	@Bean
+	public ValidationSupportChain.CacheConfiguration validationSupportChainCacheConfiguration() {
+		return ValidationSupportChain.CacheConfiguration.defaultValues();
+	}
+
+	@Bean
+	public org.hl7.fhir.common.hapi.validation.validator.WorkerContextValidationSupportAdapter workerContextValidationSupportAdapter() {
+		return new org.hl7.fhir.common.hapi.validation.validator.WorkerContextValidationSupportAdapter();
+	}
+
 	@Bean(name = JpaConfig.JPA_VALIDATION_SUPPORT_CHAIN)
 	@Primary
 	public IValidationSupport jpaValidationSupportChain() {
-		return new JpaValidationSupportChain(myFhirContext);
+		return new JpaValidationSupportChain(myFhirContext, validationSupportChainCacheConfiguration(), workerContextValidationSupportAdapter());
 	}
 
 	@Bean("myDaoRegistry")
@@ -659,14 +671,14 @@ public class JpaConfig {
 	@Bean
 	@Scope("prototype")
 	public ResourceLinkPredicateBuilder newResourceLinkPredicateBuilder(
-			QueryStack theQueryStack, SearchQueryBuilder theSearchBuilder, boolean theReversed) {
-		return new ResourceLinkPredicateBuilder(theQueryStack, theSearchBuilder, theReversed);
+			QueryStack theQueryStack, SearchQueryBuilder theSearchBuilder) {
+		return new ResourceLinkPredicateBuilder(theQueryStack, theSearchBuilder);
 	}
 
 	@Bean
 	@Scope("prototype")
-	public ResourceTablePredicateBuilder newResourceTablePredicateBuilder(SearchQueryBuilder theSearchBuilder) {
-		return new ResourceTablePredicateBuilder(theSearchBuilder);
+	public ResourceTablePredicateBuilder newResourceTablePredicateBuilder(SearchQueryBuilder theSearchBuilder, ca.uhn.fhir.rest.api.SearchIncludeDeletedEnum theSearchIncludeDeleted) {
+		return new ResourceTablePredicateBuilder(theSearchBuilder, theSearchIncludeDeleted);
 	}
 
 	@Bean
@@ -942,7 +954,8 @@ public class JpaConfig {
 			IJobCoordinator theJobCoordinator,
 			ReplaceReferencesPatchBundleSvc theReplaceReferencesPatchBundle,
 			Batch2TaskHelper theBatch2TaskHelper,
-			JpaStorageSettings theStorageSettings) {
+			JpaStorageSettings theStorageSettings,
+			ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc theReplaceReferencesProvenanceSvc) {
 		return new ReplaceReferencesSvcImpl(
 				theDaoRegistry,
 				theHapiTransactionService,
@@ -950,7 +963,8 @@ public class JpaConfig {
 				theJobCoordinator,
 				theReplaceReferencesPatchBundle,
 				theBatch2TaskHelper,
-				theStorageSettings);
+				theStorageSettings,
+				theReplaceReferencesProvenanceSvc);
 	}
 
 	@Bean
@@ -959,10 +973,126 @@ public class JpaConfig {
 	}
 
 	@Bean
+	@Primary
+	public ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc replaceReferencesProvenanceSvc(DaoRegistry theDaoRegistry) {
+		return new ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc(theDaoRegistry);
+	}
+
+	@Bean
+	public ca.uhn.fhir.jpa.dao.IResourceMetadataExtractorSvc resourceMetadataExtractorSvc(
+			JpaStorageSettings theStorageSettings,
+			ca.uhn.fhir.jpa.dao.data.IResourceHistoryTagDao theResourceHistoryTagDao,
+			ca.uhn.fhir.jpa.dao.data.IResourceTagDao theResourceTagDao,
+			ca.uhn.fhir.jpa.dao.data.IResourceHistoryProvenanceDao theResourceHistoryProvenanceDao) {
+		return new ca.uhn.fhir.jpa.dao.ResourceMetadataExtractorSvcImpl(
+				theStorageSettings, theResourceHistoryTagDao, theResourceTagDao, theResourceHistoryProvenanceDao);
+	}
+
+	@Bean
 	public PartitionedIdModeVerificationSvc partitionedIdModeVerificationSvc(
 			PartitionSettings thePartitionSettings,
 			HibernatePropertiesProvider theHibernatePropertiesProvider,
 			PlatformTransactionManager theTxManager) {
 		return new PartitionedIdModeVerificationSvc(thePartitionSettings, theHibernatePropertiesProvider, theTxManager);
+	}
+
+	@Bean
+	public ca.uhn.fhir.jpa.cache.ISearchParamIdentityCacheSvc searchParamIdentityCacheSvc(
+			@Autowired ca.uhn.fhir.jpa.dao.data.IResourceIndexedSearchParamIdentityDao theResourceIndexedSearchParamIdentityDao,
+			@Autowired PlatformTransactionManager theTxManager,
+			@Autowired MemoryCacheService theMemoryCacheService) {
+		return new ca.uhn.fhir.jpa.sp.SearchParamIdentityCacheSvcImpl(
+				myStorageSettings, theResourceIndexedSearchParamIdentityDao, theTxManager, theMemoryCacheService);
+	}
+
+	@Bean
+	public ca.uhn.fhir.jpa.cache.IResourceTypeCacheSvc resourceTypeCacheSvc(
+			@Autowired ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService theHapiTransactionService,
+			@Autowired ca.uhn.fhir.jpa.dao.data.IResourceTypeDao theResourceTypeDao,
+			@Autowired MemoryCacheService theMemoryCacheService) {
+		return new ca.uhn.fhir.jpa.cache.ResourceTypeCacheSvcImpl(theHapiTransactionService, theResourceTypeDao, theMemoryCacheService);
+	}
+
+	@Bean
+	public ca.uhn.fhir.jpa.cache.IResourceIdentifierCacheSvc resourceIdentifierCacheSvc(
+			ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService theTransactionService,
+			MemoryCacheService theMemoryCache,
+			ca.uhn.fhir.jpa.dao.data.IResourceIdentifierSystemEntityDao theResourceIdentifierSystemEntityDao,
+			ca.uhn.fhir.jpa.dao.data.IResourceIdentifierPatientUniqueEntityDao theResourceIdentifierPatientUniqueEntityDao,
+			jakarta.persistence.EntityManager theEntityManager) {
+		return new ca.uhn.fhir.jpa.cache.ResourceIdentifierCacheSvcImpl(
+				theTransactionService,
+				theMemoryCache,
+				theResourceIdentifierSystemEntityDao,
+				theResourceIdentifierPatientUniqueEntityDao,
+				theEntityManager);
+	}
+
+	@Bean
+	@Lazy
+	public ca.uhn.fhir.jpa.interceptor.PatientCompartmentEnforcingInterceptor patientCompartmentEnforcingInterceptor(
+			FhirContext theFhirContext, IRequestPartitionHelperSvc theRequestPartitionHelperSvc) {
+		return new ca.uhn.fhir.jpa.interceptor.PatientCompartmentEnforcingInterceptor(theFhirContext, theRequestPartitionHelperSvc);
+	}
+
+	@Bean
+	public ca.uhn.fhir.rest.server.interceptor.auth.IAuthResourceResolver authResourceResolver(
+			DaoRegistry theDaoRegistry, IRequestPartitionHelperSvc theRequestPartitionHelperSvc) {
+		return new ca.uhn.fhir.jpa.interceptor.AuthResourceResolver(theDaoRegistry, theRequestPartitionHelperSvc);
+	}
+
+	@Bean
+	@Lazy
+	public ca.uhn.fhir.jpa.provider.ConceptMapAddAndRemoveMappingProvider conceptMapAddAndRemoveMappingProvider(
+			ca.uhn.fhir.jpa.api.dao.IFhirResourceDaoConceptMap<?> theConceptMapDao) {
+		return new ca.uhn.fhir.jpa.provider.ConceptMapAddAndRemoveMappingProvider(theConceptMapDao);
+	}
+
+	@Bean
+	public ca.uhn.fhir.replacereferences.PreviousResourceVersionRestorer resourceVersionRestorer(
+			DaoRegistry theDaoRegistry, HapiTransactionService theHapiTransactionService) {
+		return new ca.uhn.fhir.replacereferences.PreviousResourceVersionRestorer(theDaoRegistry, theHapiTransactionService);
+	}
+
+	@Bean
+	public ca.uhn.fhir.replacereferences.UndoReplaceReferencesSvc getUndoReplaceReferencesSvc(
+			DaoRegistry theDaoRegistry,
+			ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc theProvenanceSvc,
+			ca.uhn.fhir.replacereferences.PreviousResourceVersionRestorer theResourceVersionRestorer) {
+		return new ca.uhn.fhir.replacereferences.UndoReplaceReferencesSvc(theDaoRegistry, theProvenanceSvc, theResourceVersionRestorer);
+	}
+
+	@Bean
+	public ca.uhn.fhir.rest.api.server.bulk.IBulkDataExportHistoryHelper bulkDataExportHistoryHelper() {
+		return new ca.uhn.fhir.jpa.dao.JpaBulkDataExportHistoryHelper();
+	}
+
+	@Bean(name = PERSISTED_JPA_ID_SEARCH_BUNDLE_PROVIDER)
+	@Scope("prototype")
+	public ca.uhn.fhir.jpa.search.PersistedJpaIdSearchBundleProvider newPersistedJpaIdSearchBundleProvider(
+			String theResourceType,
+			java.util.List<IResourcePersistentId<?>> theResourceIds,
+			RequestPartitionId thePartitionId,
+			@Nullable Date theRangeStartInclusive,
+			@jakarta.annotation.Nonnull Date theRangeEndInclusive) {
+		return new ca.uhn.fhir.jpa.search.PersistedJpaIdSearchBundleProvider(
+				theResourceType, theResourceIds, thePartitionId, theRangeStartInclusive, theRangeEndInclusive);
+	}
+
+	@Bean("newHasLinkPredicateBuilder")
+	@Scope("prototype")
+	public ca.uhn.fhir.jpa.search.builder.predicate.ResourceLinkForHasParameterPredicateBuilder newHasLinkPredicateBuilder(
+			ca.uhn.fhir.jpa.search.builder.QueryStack theQueryStack, ca.uhn.fhir.jpa.search.builder.sql.SearchQueryBuilder theSearchBuilder) {
+		return new ca.uhn.fhir.jpa.search.builder.predicate.ResourceLinkForHasParameterPredicateBuilder(theQueryStack, theSearchBuilder);
+	}
+
+	@Bean(name = HISTORY_BUILDER_WITH_IDS)
+	@Scope("prototype")
+	public HistoryBuilder newHistoryBuilderWithIds(
+			@jakarta.annotation.Nonnull String theResourceType,
+			@jakarta.annotation.Nonnull java.util.List<IResourcePersistentId<?>> theResourceIds,
+			@Nullable Date theRangeStartInclusive,
+			@jakarta.annotation.Nonnull Date theRangeEndInclusive) {
+		return new HistoryBuilder(theResourceType, theResourceIds, theRangeStartInclusive, theRangeEndInclusive);
 	}
 }

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -772,6 +772,81 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 	}
 
 	@Override
+	@Transactional(readOnly = true)
+	public List<IBaseResource> loadPackageAssetsByUrl(FhirVersionEnum theFhirVersion, String theCanonicalUrl, org.springframework.data.domain.PageRequest thePageRequest) {
+		String canonicalUrl = theCanonicalUrl;
+		int versionSeparator = canonicalUrl.lastIndexOf('|');
+		Slice<NpmPackageVersionResourceEntity> slice;
+		if (versionSeparator != -1) {
+			String canonicalVersion = canonicalUrl.substring(versionSeparator + 1);
+			canonicalUrl = canonicalUrl.substring(0, versionSeparator);
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrlAndVersion(
+					thePageRequest, theFhirVersion, canonicalUrl, canonicalVersion);
+		} else {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrl(
+					thePageRequest, theFhirVersion, canonicalUrl);
+		}
+		return slice.stream().map(this::loadPackageEntity).collect(Collectors.toList());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<NpmPackageAssetInfoJson> findPackageAssetInfoByUrl(FhirVersionEnum theFhirVersion, String theCanonicalUrl) {
+		String canonicalUrl = theCanonicalUrl;
+		int versionSeparator = canonicalUrl.lastIndexOf('|');
+		Slice<NpmPackageVersionResourceEntity> slice;
+		if (versionSeparator != -1) {
+			String canonicalVersion = canonicalUrl.substring(versionSeparator + 1);
+			canonicalUrl = canonicalUrl.substring(0, versionSeparator);
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrlAndVersion(
+					PageRequest.of(0, 1000), theFhirVersion, canonicalUrl, canonicalVersion);
+		} else {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrl(
+					PageRequest.of(0, 1000), theFhirVersion, canonicalUrl);
+		}
+		return slice.stream().map(e -> new NpmPackageAssetInfoJson(
+				null, e.getCanonicalUrl(), e.getFhirVersion(), e.getPackageVersion().getPackageId(), e.getPackageVersion().getVersionId()
+		)).collect(Collectors.toList());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public IBaseResource findPackageAsset(FindPackageAssetRequest theRequest) {
+		String canonicalUrl = theRequest.getCanonicalUrl();
+		FhirVersionEnum fhirVersion = theRequest.getFhirVersion();
+		String version = theRequest.getVersion();
+		Slice<NpmPackageVersionResourceEntity> slice;
+		if (version != null) {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrlAndVersion(
+					PageRequest.of(0, 1), fhirVersion, canonicalUrl, version);
+		} else {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrl(
+					PageRequest.of(0, 1), fhirVersion, canonicalUrl);
+		}
+		if (slice.isEmpty()) {
+			return null;
+		}
+		return loadPackageEntity(slice.getContent().get(0));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<IBaseResource> findPackageAssets(FindPackageAssetRequest theRequest) {
+		String canonicalUrl = theRequest.getCanonicalUrl();
+		FhirVersionEnum fhirVersion = theRequest.getFhirVersion();
+		String version = theRequest.getVersion();
+		Slice<NpmPackageVersionResourceEntity> slice;
+		if (version != null) {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrlAndVersion(
+					theRequest.getPageRequest(), fhirVersion, canonicalUrl, version);
+		} else {
+			slice = myPackageVersionResourceDao.findCurrentVersionByCanonicalUrl(
+					theRequest.getPageRequest(), fhirVersion, canonicalUrl);
+		}
+		return slice.stream().map(this::loadPackageEntity).collect(Collectors.toList());
+	}
+
+	@Override
 	@Transactional
 	public List<IBaseResource> loadPackageAssetsByType(FhirVersionEnum theFhirVersion, String theResourceType) {
 		//		List<NpmPackageVersionResourceEntity> outcome = myPackageVersionResourceDao.findAll();

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -9,7 +9,6 @@ import ca.uhn.fhir.jpa.model.config.PartitionSettings.CrossPartitionReferenceMod
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.util.JpaHibernatePropertiesProvider;
-import ca.uhn.fhir.jpa.subscription.channel.subscription.SubscriptionDeliveryHandlerFactory;
 import ca.uhn.fhir.jpa.subscription.match.deliver.email.EmailSenderImpl;
 import ca.uhn.fhir.jpa.subscription.match.deliver.email.IEmailSender;
 import ca.uhn.fhir.rest.server.mail.IMailSvc;

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -26,7 +26,7 @@ import com.google.common.base.Strings;
 
 import ca.uhn.fhir.batch2.jobs.export.BulkDataExportProvider;
 import ca.uhn.fhir.batch2.jobs.imprt.BulkDataImportProvider;
-import ca.uhn.fhir.batch2.jobs.reindex.ReindexProvider;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.reindex.ReindexProvider;
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -3275,7 +3275,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 	private org.hl7.fhir.r4.model.ValueSet getValueSetFromResourceTable(ResourceTable theResourceTable) {
 		Class<? extends IBaseResource> type =
 				getFhirContext().getResourceDefinition("ValueSet").getImplementingClass();
-		IBaseResource valueSet = myJpaStorageResourceParser.toResource(type, theResourceTable, null, false);
+		IBaseResource valueSet = myJpaStorageResourceParser.toResource(null, type, theResourceTable, null, false);
 		return myVersionCanonicalizer.valueSetToCanonical(valueSet);
 	}
 

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/validation/JpaValidationSupportChain.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/validation/JpaValidationSupportChain.java
@@ -61,7 +61,21 @@ public class JpaValidationSupportChain extends ValidationSupportChain {
 		super((IValidationSupport) null);
 
 		assert theFhirContext != null;
-//		assert theCacheConfiguration != null;
+
+		myFhirContext = theFhirContext;
+	}
+
+	/**
+	 * Constructor (HAPI 8.8.0 compatible)
+	 */
+	public JpaValidationSupportChain(
+			FhirContext theFhirContext,
+			ValidationSupportChain.CacheConfiguration theCacheConfiguration,
+			org.hl7.fhir.common.hapi.validation.validator.WorkerContextValidationSupportAdapter theWorkerContextValidationSupportAdapter) {
+		super(theCacheConfiguration, (IValidationSupport) null);
+
+		assert theFhirContext != null;
+		assert theCacheConfiguration != null;
 
 		myFhirContext = theFhirContext;
 	}

--- a/matchbox-server/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorResourceFetcher.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorResourceFetcher.java
@@ -31,7 +31,6 @@ import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import org.hl7.fhir.common.hapi.validation.validator.VersionSpecificWorkerContextWrapper;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r5.model.IdType;

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/config/MatchboxJpaConfig.java
@@ -24,7 +24,7 @@ import ca.uhn.fhir.jpa.bulk.export.model.ExportPIDIteratorParameters;
 import ca.uhn.fhir.jpa.dao.data.IBatch2JobInstanceRepository;
 import ca.uhn.fhir.jpa.dao.data.IBatch2WorkChunkMetadataViewRepository;
 import ca.uhn.fhir.jpa.dao.data.IBatch2WorkChunkRepository;
-import ca.uhn.fhir.jpa.dao.mdm.MdmExpansionCacheSvc;
+import ca.uhn.fhir.mdm.svc.MdmExpansionCacheSvc;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.delete.ThreadSafeResourceDeleterSvc;
 import ca.uhn.fhir.jpa.packages.IHapiPackageCacheManager;
@@ -364,14 +364,22 @@ public class MatchboxJpaConfig extends StarterJpaConfig {
 
 			@Override
 			public void expandMdmResources(List theResources) {
-				// TODO Auto-generated method stub
 				throw new UnsupportedOperationException("Unimplemented method 'expandMdmResources'");
 			}
 
 			@Override
 			public Iterator getResourcePidIterator(ExportPIDIteratorParameters theParams) {
-				// TODO Auto-generated method stub
 				throw new UnsupportedOperationException("Unimplemented method 'getResourcePidIterator'");
+			}
+
+			@Override
+			public Set<String> getPatientSetForGroupExport(ExportPIDIteratorParameters theParams) {
+				throw new UnsupportedOperationException("Unimplemented method 'getPatientSetForGroupExport'");
+			}
+
+			@Override
+			public Set<String> getPatientSetForPatientExport(ExportPIDIteratorParameters theParams) {
+				throw new UnsupportedOperationException("Unimplemented method 'getPatientSetForPatientExport'");
 			}
 		};
 	}

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR4.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR4.java
@@ -261,7 +261,6 @@ public class ImplementationGuideProviderR4 extends ImplementationGuideResourcePr
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 	}
 
-	@Override
 	@Search(allowUnknownParams=true)
 	public ca.uhn.fhir.rest.api.server.IBundleProvider search(
 			jakarta.servlet.http.HttpServletRequest theServletRequest,

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR4B.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR4B.java
@@ -261,7 +261,6 @@ public class ImplementationGuideProviderR4B extends ImplementationGuideResourceP
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 	}
 
-	@Override
 	@Search(allowUnknownParams=true)
 	public ca.uhn.fhir.rest.api.server.IBundleProvider search(
 			jakarta.servlet.http.HttpServletRequest theServletRequest,

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR5.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/packages/ImplementationGuideProviderR5.java
@@ -238,7 +238,6 @@ public class ImplementationGuideProviderR5 extends ImplementationGuideResourcePr
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 	}
 
-	@Override
 	@Search(allowUnknownParams=true)
 	public ca.uhn.fhir.rest.api.server.IBundleProvider search(
 			jakarta.servlet.http.HttpServletRequest theServletRequest,

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.0.20</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -41,7 +41,7 @@
         <maven.compiler.release>21</maven.compiler.release>
 
         <fhir.core.version>6.9.1</fhir.core.version>
-        <hapi.fhir.version>8.0.0</hapi.fhir.version>
+        <hapi.fhir.version>8.8.0</hapi.fhir.version>
 
 
         <!-- The following section closely matches the one of HAPI-FHIR (for easier version comparison/upgrade).
@@ -54,12 +54,12 @@
         <commons_lang3_version>3.18.0</commons_lang3_version>
         <junit_version>5.13.1</junit_version>
         <logback_version>1.5.29</logback_version>
-        <jackson_version>2.17.1</jackson_version>
+        <jackson_version>2.19.4</jackson_version>
         <okhttp_version>4.12.0</okhttp_version>
         <log4j_to_slf4j_version>2.19.0</log4j_to_slf4j_version>
-        <spring_version>6.1.21</spring_version>
-        <spring_context_version>6.1.21</spring_context_version>
-        <spring_boot_version>3.3.13</spring_boot_version>
+        <spring_version>6.2.12</spring_version>
+        <spring_context_version>6.2.12</spring_context_version>
+        <spring_boot_version>3.5.9</spring_boot_version>
         <testcontainers_version>1.21.1</testcontainers_version>
         <ucum_version>1.0.10</ucum_version>
 
@@ -133,6 +133,21 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>5.3.4</version>
+            </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>


### PR DESCRIPTION
## Summary

- Upgrade HAPI FHIR from 8.0.0 to 8.8.0 (aligning with upstream `image/v8.8.0-1`)
- Upgrade Spring Boot from 3.3.13 to 3.5.9, Spring Framework from 6.1.21 to 6.2.12
- Upgrade Jackson from 2.17.1 to 2.19.4, Apache HttpClient5 to 5.5
- Keep `fhir.core.version` at 6.9.1 (matchbox patches depend on it)
- Bump project version to 4.1.0

### Breaking API changes fixed (15 files)

- **JpaConfig.java**: Added 14 new bean definitions required by HAPI 8.8.0 (`searchParamIdentityCacheSvc`, `resourceTypeCacheSvc`, `resourceIdentifierCacheSvc`, `workerContextValidationSupportAdapter`, `validationSupportChainCacheConfiguration`, `resourceVersionRestorer`, `bulkDataExportHistoryHelper`, etc.), fixed changed constructors
- **JpaValidationSupportChain.java**: Added 3-arg constructor for HAPI 8.8.0 compatibility
- **JpaPackageCache.java**: Implemented new `IHapiPackageCacheManager` interface methods
- **MatchboxJpaConfig.java**: Added new `IBulkExportProcessor` methods, fixed moved packages
- **TermReadSvcImpl.java**: Fixed `toResource` signature change
- **StarterJpaConfig.java**: Fixed `ReindexProvider` package relocation
- **ImplementationGuideProviderR4/R4B/R5.java**: Removed `@Override` on changed parent method
- **ValidatorResourceFetcher.java**, **FhirServerConfigCommon.java**: Removed deleted class imports

## Test plan

- [x] `mvn clean test -pl matchbox-engine` passes (97 tests, 0 failures)
- [x] `mvn clean test -pl matchbox-server` passes (40 tests, 0 failures, 2 skipped)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)