### PR TITLE
Fix npm security vulnerabilities (hono, serialize-javascript, minimatch)

### DIFF
--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -11451,9 +11451,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13827,9 +13827,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -15486,16 +15486,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16279,13 +16269,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/matchbox-frontend/package.json
+++ b/matchbox-frontend/package.json
@@ -90,6 +90,9 @@
   "overrides": {
     "lodash-es": "npm:lodash-es@4.17.23",
     "flatted": "3.4.2",
-    "undici": "7.24.0"
+    "undici": "7.24.0",
+    "hono": "4.12.2",
+    "serialize-javascript": ">=7.0.3",
+    "minimatch@>=9.0.0 <9.0.7": "9.0.7"
   }
 }


### PR DESCRIPTION
## Summary
- Override `hono` to 4.12.2 — authentication bypass via IP spoofing in AWS Lambda ALB conninfo (#224)
- Override `serialize-javascript` to >=7.0.3 — RCE via `RegExp.flags` and `Date.prototype.toISOString()` (#233)
- Override `minimatch` >=9.0.0 to 9.0.7 — ReDoS via multiple non-adjacent GLOBSTAR segments (#231)

## Test plan
- [x] Frontend builds successfully
- [x] Backend compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)