### PR TITLE
Fix hono arbitrary file access vulnerability (#234)

### DIFF
--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -56,6 +56,7 @@
         "@typescript-eslint/eslint-plugin": "8.55.x",
         "@typescript-eslint/parser": "8.55.x",
         "eslint": "^9.15.0",
+        "hono": ">=4.12.7",
         "jasmine": "5.13.x",
         "jasmine-core": "5.13.x",
         "jasmine-spec-reporter": "^7.0.0",
@@ -11451,9 +11452,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/matchbox-frontend/package.json
+++ b/matchbox-frontend/package.json
@@ -61,6 +61,7 @@
     "@typescript-eslint/eslint-plugin": "8.55.x",
     "@typescript-eslint/parser": "8.55.x",
     "eslint": "^9.15.0",
+    "hono": ">=4.12.7",
     "jasmine": "5.13.x",
     "jasmine-core": "5.13.x",
     "jasmine-spec-reporter": "^7.0.0",
@@ -91,8 +92,7 @@
     "lodash-es": "npm:lodash-es@4.17.23",
     "flatted": "3.4.2",
     "undici": "7.24.0",
-    "hono": "4.12.2",
-    "serialize-javascript": ">=7.0.3",
+"serialize-javascript": ">=7.0.3",
     "minimatch@>=9.0.0 <9.0.7": "9.0.7"
   }
 }


### PR DESCRIPTION
## Summary
- Move `hono` to devDependency at `>=4.12.7` instead of pinning via override at 4.12.2
- Resolves arbitrary file access via `serveStatic` vulnerability (dependabot #234)
- hono now resolves to 4.12.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)