### PR TITLE
chore: exclude the AWS elasticsearch configurer

### DIFF
--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -57,6 +57,12 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-jpaserver-base</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-backend-elasticsearch-aws</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>


### PR DESCRIPTION
We don't need the AWS-related dependencies.