### PR TITLE
Release 4.1.5: fix HIGH CVEs in Debian base image

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+2026/04/20 Release 4.1.5
+
+- Apply Debian security patches in the server Docker image (`apt-get upgrade` on base image) to fix HIGH CVEs CVE-2026-33416, CVE-2026-33636 (libpng16-16) and CVE-2026-28390 (openssl/libssl3)
+
 2026/04/17 Release 4.1.4
 
 - Upgrade thymeleaf from 3.1.2.RELEASE to 3.1.4.RELEASE to fix CVE-2026-40478

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/Dockerfile
+++ b/matchbox-server/Dockerfile
@@ -1,6 +1,11 @@
 FROM bellsoft/liberica-openjdk-debian:26
 EXPOSE 8080
 
+# Apply latest Debian security patches to the base image
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./target/matchbox.jar /matchbox.jar
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.1.4</version>
+    <version>4.1.5</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or


### PR DESCRIPTION
## Summary

- Bump version to **4.1.5** across all `pom.xml` files.
- Add `apt-get update && apt-get upgrade` to `matchbox-server/Dockerfile` to pick up the latest Debian 12 security patches in the `bellsoft/liberica-openjdk-debian:26` base image.
- Update `docs/changelog.md` with 2026/04/20 release entry.