### PR TITLE
ci: scan built Docker image with Trivy for OS-package CVEs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,3 +88,51 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+          category: 'trivy-fs'
+
+  test-trivy-docker-image:
+    name: Build Docker image and scan with Trivy
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v5
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: adopt
+          cache: maven
+
+      - name: Build matchbox server jar
+        run: mvn --batch-mode --update-snapshots package -DskipTests -P release
+
+      - name: Build Docker image
+        run: docker build -t matchbox:scan -f matchbox-server/Dockerfile matchbox-server
+
+      - name: Run Trivy vulnerability scanner on Docker image
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          scan-type: 'image'
+          image-ref: 'matchbox:scan'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+          severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Trivy Docker image scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-image'


### PR DESCRIPTION
## Summary

Add a new job `test-trivy-docker-image` to `.github/workflows/security.yml` that builds the matchbox-server Docker image and runs Trivy in `image` mode against it (HIGH/CRITICAL, `ignore-unfixed: true`).

## Why

The existing Trivy job runs in `fs` (filesystem) mode against the checked-out repo. That catches Java/npm dependency CVEs but not OS packages inside the runtime image — which is exactly how the recent HIGH CVEs in libpng/openssl (fixed in #512 / 4.1.5) slipped past our own CI and were only caught by the downstream Nexus registry scan.

With this job, base-image CVEs are surfaced on every push/PR and nightly, same cadence as the other security checks.

## Notes

- Categorised SARIF uploads (`trivy-fs` vs `trivy-image`) so the two Trivy reports show up as separate entries under the GitHub Security tab instead of overwriting each other.
- Build step mirrors `googleregistry.yml`: `mvn package -DskipTests -P release` then `docker build` of `matchbox-server/Dockerfile`. Single platform (amd64) is enough for CVE scanning.
- No changelog entry — CI-only change.