### PR TITLE
ci: disable Trivy Rekor SBOM lookup on image scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,6 +99,7 @@ jobs:
       security-events: write
 
     steps:
+      
       - name: Checkout the repository
         uses: actions/checkout@v5
 
@@ -127,6 +128,9 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1
+          # Skip Rekor SBOM attestation lookup — rekor.sigstore.dev is flaky and
+          # causes the scan to fail with "failed to search rekor records".
+          TRIVY_OFFLINE_SCAN: 'true'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Set `TRIVY_OFFLINE_SCAN=true` on the new `test-trivy-docker-image` job so Trivy skips the Rekor SBOM attestation lookup during image layer analysis.

## Why

The image-mode scan added in #513 is failing with:

```
FATAL Fatal error
  - failed to search rekor records
  - Post "https://rekor.sigstore.dev/api/v1/index/retrieve": giving up after 4 attempt(s)
```

Trivy's image post-handler queries `rekor.sigstore.dev` for SBOM attestations of each layer. Rekor is flaky / rate-limiting CI traffic and the scan fails even though the actual vulnerability detection would have succeeded.

`offline-scan` disables the outbound API calls Trivy makes to identify dependencies (including the Rekor SBOM lookup). The local vulnerability DB download is unaffected — the scan itself still runs with up-to-date data. For our purpose (catching OS-package CVEs in the runtime image) we don't need the SBOM-in-Rekor lookup at all.