### PR TITLE
Release 4.1.6: security dependency upgrades

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
-2026/05/xx Release 4.1.6
+2026/05/07 Release 4.1.6
 
 - Add validation statistics feature (#462)
+- Upgrade Spring Boot from 3.5.12 to 3.5.14 to fix predictable temp directory vulnerability (CVE-2026-40973)
+- Upgrade Thymeleaf from 3.1.4.RELEASE to 3.1.5.RELEASE to fix improper recognition of unauthorized syntax patterns (CVE-2026-40478)
+- Upgrade PostgreSQL JDBC driver from 42.7.10 to 42.7.11 to fix SCRAM-SHA-256 authentication DoS vulnerability (CVE-2026-42198)
 
 2026/04/20 Release 4.1.5
 

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -2730,6 +2730,43 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",

--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matchbox",
-  "version": "4.1.1",
+  "version": "4.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matchbox",
-      "version": "4.1.1",
+      "version": "4.1.6",
       "license": "MIT",
       "dependencies": {
         "@ngx-translate/core": "^17.0.0",
@@ -2728,43 +2728,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/matchbox-frontend/package.json
+++ b/matchbox-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matchbox",
-  "version": "4.1.1",
+  "version": "4.1.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.6</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -59,8 +59,8 @@
         <log4j_to_slf4j_version>2.19.0</log4j_to_slf4j_version>
         <spring_version>6.2.17</spring_version>
         <spring_context_version>6.2.17</spring_context_version>
-        <spring_boot_version>3.5.12</spring_boot_version>
-        <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version>
+        <spring_boot_version>3.5.14</spring_boot_version>
+        <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
         <testcontainers_version>1.21.4</testcontainers_version>
         <ucum_version>1.0.10</ucum_version>
 
@@ -80,7 +80,7 @@
         <!-- Other dependencies we need -->
         <lombok_version>1.18.44</lombok_version>
         <undertow_version>2.3.24.Final</undertow_version>
-        <postgresql_version>42.7.10</postgresql_version>
+        <postgresql_version>42.7.11</postgresql_version>
         <h2_version>2.4.240</h2_version>
         <jakarta_servlet_version>6.1.0</jakarta_servlet_version>
         <jaxb_api_version>2.3.1</jaxb_api_version>


### PR DESCRIPTION
## Summary

- Bump project version to **4.1.6**
- Upgrade **Spring Boot 3.5.12 → 3.5.14** — fixes CVE-2026-40973 (predictable temp directory without ownership verification, HIGH) — addresses code-scanning alert [#357](https://github.com/ahdis/matchbox/security/code-scanning/357)
- Upgrade **Thymeleaf 3.1.4.RELEASE → 3.1.5.RELEASE** — fixes CVE-2026-40478 (improper recognition of unauthorized syntax patterns) — addresses Dependabot alert [#306](https://github.com/ahdis/matchbox/security/dependabot/306)
- Upgrade **PostgreSQL JDBC 42.7.10 → 42.7.11** — fixes CVE-2026-42198 (SCRAM-SHA-256 authentication CPU exhaustion DoS, HIGH) — addresses Dependabot alert [#308](https://github.com/ahdis/matchbox/security/dependabot/308) and code-scanning alert [#356](https://github.com/ahdis/matchbox/security/code-scanning/356)