### PR TITLE
fix(security): patch CVE-2026-40682/42027/42440, CVE-2026-44728, CVE-2026-6321 and fix Trivy CI scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -128,9 +128,10 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1
-          # Skip Rekor SBOM attestation lookup — rekor.sigstore.dev is flaky and
-          # causes the scan to fail with "failed to search rekor records".
-          TRIVY_OFFLINE_SCAN: 'true'
+          # Skip Rekor SBOM attestation lookup — rekor.sigstore.dev times out in CI
+          # and causes the scan to fail before the SARIF output is written.
+          # TRIVY_OFFLINE_SCAN only stops DB update fetches, not SBOM source lookups.
+          TRIVY_SBOM_SOURCES: ''
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+2026/05/11 Release 4.1.7
+
+- Force opennlp-tools >= 2.5.9 to fix CVE-2026-40682, CVE-2026-42027, CVE-2026-42440 (transitive via langchain4j)
+- Fix Trivy Docker image scan failing due to rekor.sigstore.dev timeout: replace TRIVY_OFFLINE_SCAN with TRIVY_SBOM_SOURCES='' to skip SBOM attestation lookups
+- Pin @babel/plugin-transform-modules-systemjs >= 7.29.4 to fix CVE-2026-44728 (arbitrary code generation via malicious input)
+- Pin fast-uri >= 3.1.1 to fix CVE-2026-6321 (path traversal via percent-encoded dot segments)
+
 2026/05/07 Release 4.1.6
 
 - Re-add support for the JRE 17 in matchbox-engine (#510)

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.6</version>
+        <version>4.1.7</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -2730,6 +2730,43 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",

--- a/matchbox-frontend/package-lock.json
+++ b/matchbox-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matchbox",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matchbox",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "MIT",
       "dependencies": {
         "@ngx-translate/core": "^17.0.0",
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,43 +2728,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -11285,9 +11248,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/matchbox-frontend/package.json
+++ b/matchbox-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matchbox",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -99,6 +99,8 @@
     "hono": ">=4.12.7",
     "@hono/node-server": ">=1.19.10",
     "dompurify": ">=3.3.2",
-    "lodash": ">=4.18.0"
+    "lodash": ">=4.18.0",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "fast-uri": ">=3.1.1"
   }
 }

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.6</version>
+        <version>4.1.7</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.1.6</version>
+    <version>4.1.7</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -133,6 +133,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Force opennlp-tools >= 2.5.9 to fix CVE-2026-40682, CVE-2026-42027, CVE-2026-42440 (transitive via langchain4j) -->
+            <dependency>
+                <groupId>org.apache.opennlp</groupId>
+                <artifactId>opennlp-tools</artifactId>
+                <version>2.5.9</version>
+            </dependency>
             <dependency>
                 <groupId>org.thymeleaf</groupId>
                 <artifactId>thymeleaf</artifactId>


### PR DESCRIPTION
## Summary

- **Backend (Java)**: Force `opennlp-tools` to `2.5.9` via `dependencyManagement` in root `pom.xml` to fix three CVEs in the transitive dependency pulled in by `langchain4j:1.0.0-beta1` (which ships `1.9.4`):
  - CVE-2026-40682 (CRITICAL) — XXE via unsanitized dictionary parsing
  - CVE-2026-42027 (CRITICAL) — arbitrary class loading via model manifest
  - CVE-2026-42440 (HIGH) — OOM DoS via unbounded array allocation
- **Frontend (npm)**: Add two `overrides` entries in `package.json` to force patched transitive deps pulled in by `@angular-devkit/build-angular`:
  - `@babel/plugin-transform-modules-systemjs >= 7.29.4` — fixes CVE-2026-44728 (HIGH, arbitrary code generation)
  - `fast-uri >= 3.1.1` — fixes CVE-2026-6321 (HIGH, path traversal via percent-encoded dot segments)
- **CI**: Fix Trivy Docker image scan failing with a `context deadline exceeded` timeout on `rekor.sigstore.dev`. Replace `TRIVY_OFFLINE_SCAN: true` (which only suppresses vulnerability DB update fetches) with `TRIVY_SBOM_SOURCES: ''` to actually skip SBOM attestation lookups against Rekor.