### PR TITLE
4.1.9: Bump Undertow, Spring Framework, Spring AI for security fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+2026/05/27 Release 4.1.9
+
+- Upgrade Undertow from 2.3.24.Final to 2.4.1.Final to fix DoS via multipart/form-data parsing on HTTP GET requests (CVE-2026-3260)
+- Upgrade Spring Framework from 6.2.17 to 6.2.18 to fix DoS via static resource resolution on Windows (CVE-2026-22745)
+- Update spring ai to 1.0.7 for CVE-2026-41712 
+
 2026/05/26 Release 4.1.8
 
 - Fix for loading custom SearchParameter -Exception during startup (#520) when matchbox.validation.save-statistics is enabled

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 2026/05/27 Release 4.1.9
 
-- Upgrade Undertow from 2.3.24.Final to 2.4.1.Final to fix DoS via multipart/form-data parsing on HTTP GET requests (CVE-2026-3260)
+- Upgrade Undertow from 2.3.24.Final to 2.4.1.Final to fix DoS via multipart/form-data parsing on HTTP GET requests (CVE-2026-3260). Since Undertow 2.4.0 the servlet and websocket modules were extracted to `io.undertow.ee` (UNDERTOW-2646); we now use `io.undertow.ee:undertow-servlet:1.0.0.Final` and `io.undertow.ee:undertow-websockets:1.0.0.Final` for Jakarta EE 10 compatibility (Spring Framework 6.2).
 - Upgrade Spring Framework from 6.2.17 to 6.2.18 to fix DoS via static resource resolution on Windows (CVE-2026-22745)
 - Update spring ai to 1.0.7 for CVE-2026-41712 
 

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>
@@ -286,7 +286,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-mcp</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.7</version>
         </dependency>
         <!--
         This will be included as well as using Spring Automatic Configuration

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -467,6 +467,27 @@
                 <dependency>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-undertow</artifactId>
+                    <exclusions>
+                        <!-- Since Undertow 2.4.0 the servlet/websocket modules moved to
+                             io.undertow.ee (UNDERTOW-2646). Drop the old transitives that
+                             Spring Boot still pulls in and bring in the new artifacts below. -->
+                        <exclusion>
+                            <groupId>io.undertow</groupId>
+                            <artifactId>undertow-servlet</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.undertow</groupId>
+                            <artifactId>undertow-websockets-jsr</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.undertow.ee</groupId>
+                    <artifactId>undertow-servlet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.undertow.ee</groupId>
+                    <artifactId>undertow-websockets</artifactId>
                 </dependency>
             </dependencies>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <!-- Other dependencies we need -->
         <lombok_version>1.18.44</lombok_version>
         <undertow_version>2.4.1.Final</undertow_version>
+        <undertow_ee_version>1.0.0.Final</undertow_ee_version>
         <postgresql_version>42.7.11</postgresql_version>
         <h2_version>2.4.240</h2_version>
         <jakarta_servlet_version>6.1.0</jakarta_servlet_version>
@@ -528,21 +529,24 @@
                 <version>${jaxb_api_version}</version>
             </dependency>
 
-            <!-- Upgrading Undertow, the version we get from Spring Boot is older -->
+            <!-- Upgrading Undertow, the version we get from Spring Boot is older.
+                 Since Undertow 2.4.0, the servlet and websocket modules were extracted to
+                 io.undertow.ee (see UNDERTOW-2646). We use the 1.0.x line for Jakarta EE 10
+                 compatibility (Spring Framework 6.2 baseline). -->
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
                 <version>${undertow_version}</version>
             </dependency>
             <dependency>
-                <groupId>io.undertow</groupId>
+                <groupId>io.undertow.ee</groupId>
                 <artifactId>undertow-servlet</artifactId>
-                <version>${undertow_version}</version>
+                <version>${undertow_ee_version}</version>
             </dependency>
             <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-websockets-jsr</artifactId>
-                <version>${undertow_version}</version>
+                <groupId>io.undertow.ee</groupId>
+                <artifactId>undertow-websockets</artifactId>
+                <version>${undertow_ee_version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.1.8</version>
+    <version>4.1.9</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -56,8 +56,8 @@
         <jackson_version>2.19.4</jackson_version>
         <okhttp_version>4.12.0</okhttp_version>
         <log4j_to_slf4j_version>2.19.0</log4j_to_slf4j_version>
-        <spring_version>6.2.17</spring_version>
-        <spring_context_version>6.2.17</spring_context_version>
+        <spring_version>6.2.18</spring_version>
+        <spring_context_version>6.2.18</spring_context_version>
         <spring_boot_version>3.5.14</spring_boot_version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
         <testcontainers_version>1.21.4</testcontainers_version>
@@ -78,7 +78,7 @@
 
         <!-- Other dependencies we need -->
         <lombok_version>1.18.44</lombok_version>
-        <undertow_version>2.3.24.Final</undertow_version>
+        <undertow_version>2.4.1.Final</undertow_version>
         <postgresql_version>42.7.11</postgresql_version>
         <h2_version>2.4.240</h2_version>
         <jakarta_servlet_version>6.1.0</jakarta_servlet_version>


### PR DESCRIPTION
## Summary

Address three Dependabot/security advisories by upgrading affected dependencies. Bumps the project version to 4.1.9 and adds the corresponding changelog entry.

- **Undertow 2.3.24.Final → 2.4.1.Final** — fixes [CVE-2026-3260](https://nvd.nist.gov/vuln/detail/CVE-2026-3260) (DoS via multipart/form-data parsing on HTTP GET requests). Resolves Dependabot alert [#302](https://github.com/ahdis/matchbox/security/dependabot/302).
- **Spring Framework 6.2.17 → 6.2.18** — fixes [CVE-2026-22745](https://nvd.nist.gov/vuln/detail/CVE-2026-22745) (DoS via static resource resolution; only exploitable on Windows hosts, but bumping anyway to satisfy the scanner). Resolves Dependabot alert [#313](https://github.com/ahdis/matchbox/security/dependabot/313).
- **spring-ai-mcp 1.0.2 → 1.0.7** — fixes CVE-2026-41712.