### PR TITLE
removed operationOutcome from mcp sampling result

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+2026/xx/xx Release 4.1.11
+
+- Fix for issue #528: Validation through MCP with AI analysis via Sampling will only get the result of the AI analysis back, not the full OperationOutcome
+
+
 2026/06/08 Release 4.1.10
 
 - Validation requests through MCP will no longer invoke a separate LLM for AI analysis. Instead matchbox will give the Operation Outcome together with a prompt back to the MCP client.

--- a/matchbox-server/src/main/java/ca/uhn/fhir/rest/server/McpMatchboxBridge.java
+++ b/matchbox-server/src/main/java/ca/uhn/fhir/rest/server/McpMatchboxBridge.java
@@ -289,7 +289,7 @@ public class McpMatchboxBridge implements McpBridge {
 					if (samplingResult != null && samplingResult.content() instanceof McpSchema.TextContent textResponse) {
 						String aiResponse = textResponse.text();
 
-						return fhirOperationOutcome + "\nAI Analysis:\n" + aiResponse;
+						return aiResponse;
 					} else {
 						return fhirOperationOutcome;
 					}


### PR DESCRIPTION
Validation through MCP with AI analysis via Sampling will only get the result of the AI analysis back, not the full OperationOutcome #528