### PR TITLE
Release 4.1.13: fix six Spring vulnerabilities pulled in via HAPI FHIR

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
-Unreleased
+2026/08/14 Release 4.1.13
 
+- Force Spring Data to 3.5.12 (`spring-data-commons`, `spring-data-jpa`, `spring-data-envers`), which HAPI FHIR still pulls in as 3.3.5, to fix three vulnerabilities in `spring-data-commons`: CVE-2026-41716 (denial of service, attacker-supplied strings are permanently retained as property-lookup cache keys and can exhaust the heap), CVE-2026-41711 and CVE-2026-41721
+- Align `spring-core` and `spring-websocket`, which HAPI FHIR pulls in as 6.2.18, with the Spring Framework version already used elsewhere (6.2.19), fixing CVE-2026-41838 in `spring-websocket` and CVE-2026-41848 in `spring-core`
+- Force `spring-retry` to 2.0.13, which HAPI FHIR pulls in as 2.0.10, to fix CVE-2026-41710
 - Fix the GUI not displaying markdown content (#555)
 
 2026/08/11 Release 4.1.12

--- a/matchbox-engine/pom.xml
+++ b/matchbox-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.12</version>
+        <version>4.1.13</version>
     </parent>
 
     <artifactId>matchbox-engine</artifactId>

--- a/matchbox-server/pom.xml
+++ b/matchbox-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>matchbox</artifactId>
         <groupId>health.matchbox</groupId>
-        <version>4.1.12</version>
+        <version>4.1.13</version>
     </parent>
 
     <artifactId>matchbox-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>health.matchbox</groupId>
     <artifactId>matchbox</artifactId>
-    <version>4.1.12</version>
+    <version>4.1.13</version>
     <packaging>pom</packaging>
     <name>matchbox</name>
     <description>An open-source implementation to support testing and implementation of FHIR based solutions and map or
@@ -60,6 +60,7 @@
         <spring_version>6.2.19</spring_version>
         <spring_context_version>6.2.19</spring_context_version>
         <spring_boot_version>3.5.16</spring_boot_version>
+        <spring_data_version>3.5.12</spring_data_version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
         <testcontainers_version>1.21.4</testcontainers_version>
         <ucum_version>1.0.10</ucum_version>
@@ -480,6 +481,27 @@
                 <artifactId>spring-webmvc</artifactId>
                 <version>${spring_version}</version>
             </dependency>
+            <!-- spring-core and spring-websocket are pulled in transitively by HAPI FHIR, which resolves them to
+                 6.2.18 while the rest of the framework is already managed at ${spring_version}. Aligning them fixes
+                 CVE-2026-41838 in spring-websocket (https://github.com/ahdis/matchbox/security/code-scanning/470)
+                 and CVE-2026-41848 in spring-core (https://github.com/ahdis/matchbox/security/code-scanning/479). -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-websocket</artifactId>
+                <version>${spring_version}</version>
+            </dependency>
+            <!-- Force spring-retry >= 2.0.13 to fix CVE-2026-41710 (transitive via hapi-fhir-jpaserver-searchparam):
+                 https://github.com/ahdis/matchbox/security/code-scanning/469 -->
+            <dependency>
+                <groupId>org.springframework.retry</groupId>
+                <artifactId>spring-retry</artifactId>
+                <version>2.0.13</version>
+            </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
@@ -490,6 +512,25 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-autoconfigure</artifactId>
                 <version>${spring_boot_version}</version>
+            </dependency>
+            <!-- Spring Data is pulled in transitively by hapi-fhir-jpaserver-base, which still resolves the
+                 3.3.x line. Force the 3.5.x line (matching spring_boot_version) to fix CVE-2026-41716:
+                 https://github.com/ahdis/matchbox/security/code-scanning/492
+                 The three artifacts are released in lock-step and must stay on the same version. -->
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-commons</artifactId>
+                <version>${spring_data_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-jpa</artifactId>
+                <version>${spring_data_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-envers</artifactId>
+                <version>${spring_data_version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Prepares the 4.1.13 patch release and closes all 11 open Trivy code-scanning alerts, which come down to six CVEs in Spring artifacts that HAPI FHIR 8.10.1 pulls in transitively at older versions. Each CVE is reported twice (once against `matchbox-server/pom.xml`, once against the built `matchbox.jar`), except `spring-retry` which only surfaced in the jar scan.

| Artifact | From | To | CVEs | Alerts |
|---|---|---|---|---|
| `spring-data-commons`, `spring-data-jpa`, `spring-data-envers` | 3.3.5 | 3.5.12 | CVE-2026-41716 (high), CVE-2026-41711, CVE-2026-41721 | 492–497 |
| `spring-websocket` | 6.2.18 | 6.2.19 | CVE-2026-41838 | 468, 470 |
| `spring-retry` | 2.0.10 | 2.0.13 | CVE-2026-41710 | 469 |
| `spring-core` | 6.2.18 | 6.2.19 | CVE-2026-41848 (low) | 471, 479 |

Notes on the version choices:

- **Spring Data 3.5.12** is the fix version for the 3.5 line (the alternative, 4.0.6, is a major jump). It pairs with the `spring_boot_version` 3.5.16 already managed here and works against the resolved Hibernate 6.6.4. The three artifacts release in lock-step and share a new `spring_data_version` property.
- **`spring-core` / `spring-websocket`** simply reuse the existing `${spring_version}`, which was already 6.2.19 but only applied to `spring-web`, `spring-webmvc` and `spring-test` — HAPI was dragging the rest in at 6.2.18. `spring-core` is only a low-severity alert, but it is the same one-line alignment and leaving the framework split across two patch versions would be worse.

Also bumps the project version 4.1.12 → 4.1.13 in the three poms and adds the changelog section.

## Test plan

- `mvn clean install` succeeds
- Full `matchbox-server` unit suite passes: 46 tests, 0 failures, 0 errors, 2 skipped, across `MatchboxApiR4Test`, `MatchboxApiR5Test`, `MatchboxApiR4BTest`, `MatchboxApiR5onR4Test`, `TransformTest`, `GazelleApiR4Test` and `MbInstalledStructureDefinitionIsCurrentTest` — each of which boots a complete JPA/Spring Data context under Undertow, so the Spring Data 3.3 → 3.5 jump is exercised at runtime and not just at compile time
- `mvn dependency:tree` confirms every artifact resolves at the intended version
- `matchbox-engine` pulls in no Spring artifacts, so these changes are confined to the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)