### PR TITLE
Revert temporary workaround for "Slicing cannot be evaluated" (#487)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ Unreleased
 - Add the configuration property `matchbox.fhir.validation.analyzeErrorsWithLlm` (#561)
 - Add the configuration property `matchbox.fhir.mcp.requestAnalysisFromClient` (#561)
 - Allow to override `llmProvider` in the validation GUI
+- Revert the temporary workaround for "Slicing cannot be evaluated" in `ProfileUtilities.findProfile()` (#487); the canonical version resolution rules are honoured again, as org.hl7.fhir.core 6.10.0 resolves versioned extension canonicals correctly
 
 2026/08/14 Release 4.1.13
 

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -4142,8 +4142,7 @@ public class ProfileUtilities {
       source = null;
     }
     // matchbox patch #424 findProfile gets called by FHIRPathEngine
-// FIXME #487  StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, ExtensionUtilities.getVersionResolutionRules(ref), v, source);
-    StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, null, null, source); 
+    StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, ExtensionUtilities.getVersionResolutionRules(ref), v, source);
     if (sd == null) {
       if (makeXVer().matchingUrl(u) && xver.status(u) == XVerExtensionStatus.Valid) {
         sd = xver.getDefinition(u);


### PR DESCRIPTION
Reverts the temporary workaround introduced in d6be291 for #487.

## What the workaround did

`ProfileUtilities.findProfile()` bypassed the canonical version resolution rules and the requested version, always fetching the unversioned StructureDefinition:

```java
// FIXME #487  StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, ExtensionUtilities.getVersionResolutionRules(ref), v, source);
StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, null, null, source);
```

This silenced `Slicing cannot be evaluated: Problem with use of resolve() - profile [CanonicalType[http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName|5.3.0-ballot-tc1]] on Address.line.extension:streetName could not be resolved`, at the cost of ignoring version-specific canonical references.

## Verification

Tested with `hl7.fhir.eu.eps#1.0.0-alpha` (from https://hl7.eu/fhir/eps/xtehr/package.tgz, along with its `hl7.fhir.eu.base#2.0.0-gamma` dependency from https://hl7.eu/fhir/base/xtehr/package.tgz — neither is in the package registries yet), validating the Patient from the issue against `http://hl7.eu/fhir/eps/StructureDefinition/patient-eu-eps`.

The setup reproduces the original ambiguity: the engine had **three versions of `hl7.fhir.uv.extensions.r4` loaded simultaneously** — 5.2.0, 5.3.0 and 5.3.0-ballot-tc1 — which is what made the versioned `iso21090-ADXP-streetName|5.3.0-ballot-tc1` canonical unresolvable before.

With the workaround reverted, the validation output is identical to the output with the workaround applied — no slicing error:

```
[information] Patient.meta.tag[0].system: A definition for CodeSystem 'https://synderai.net/fhir/CodeSystem/tags' could not be found
[warning]     Patient.extension[1]...coding[0].system: A definition for CodeSystem 'http://loinc.org/' could not be found
[warning]     Patient.identifier[0].system: No definition could be found for URL value 'http://ec.europa.eu/identifier/eci'
[warning]     Patient.identifier[1].system: No definition could be found for URL value 'http://local.setting.eu/identifier'
[information] No fatal or error issues detected, the validation has passed
```

The reverted code path was confirmed to be the one exercised (`javap` on the built jar shows `findProfile` calling `getVersionResolutionRules`), so this is not a stale-build artifact. The fix comes from org.hl7.fhir.core 6.10.0, which the engine now uses; the workaround was written against an older core.

`matchbox-engine` test suite: 96 tests, 0 failures, 0 errors (2 skipped).

No regression test is added, since that would pull the EU EPS IG dependency chain into the test suite.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)