### PR TITLE
Don't retain the narrative of package conformance resources

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ Unreleased
 - Add the configuration property `matchbox.fhir.validation.analyzeErrorsWithLlm` (#561)
 - Add the configuration property `matchbox.fhir.mcp.requestAnalysisFromClient` (#561)
 - Allow to override `llmProvider` in the validation GUI
+- Don't keep the narrative of conformance resources loaded from a package in the validation contexts, it is never used during validation and accounts for about half of the heap (#566)
 
 2026/08/14 Release 4.1.13
 

--- a/matchbox-engine/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -253,6 +253,14 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   private Map<String, Map<String, ResourceProxy>> allResourcesById = new HashMap<String, Map<String, ResourceProxy>>();
   private Map<String, List<ResourceProxy>> allResourcesByUrl = new HashMap<String, List<ResourceProxy>>();
 
+  // matchbox patch: conformance resources loaded from a package keep their narrative in memory, where it is
+  // never read: validation does not look at DomainResource.text. Measured on hl7.fhir.r4.core plus the
+  // myhealth.eu.fhir.laboratory closure, the parsed XHTML accounts for ~970 MiB of a 2.1 GiB heap.
+  // HAPI already drops narrative when it persists package resources (JpaPackageCache.addPackageToCache),
+  // so this keeps the in-memory contexts consistent with what the server serves from the database.
+  // Set -Dmatchbox.retainPackageNarrative=true to keep it.
+  private boolean stripPackageNarrative = !Boolean.getBoolean("matchbox.retainPackageNarrative");
+
   // all maps are to the full URI
   private CanonicalResourceManager<CodeSystem> codeSystems = new CanonicalResourceManager<CodeSystem>(false, minimalMemory);
   private final HashMap<String, SystemSupportInformation> supportedCodeSystems = new HashMap<>();
@@ -397,6 +405,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       suppressedMappings = other.suppressedMappings;
       cutils.setSuppressedMappings(other.suppressedMappings);
       locale = other.locale; // matchbox patch https://github.com/ahdis/matchbox/issues/425
+      stripPackageNarrative = other.stripPackageNarrative; // matchbox patch, see stripPackageNarrative
     }
   }
 
@@ -509,6 +518,13 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
 
   public void cacheResourceFromPackage(Resource r, PackageInformation packageInfo) throws FHIRException {
+    // matchbox patch: drop the narrative of resources coming from a package, see stripPackageNarrative.
+    // packageInfo is null when a resource is cached at runtime (cacheResource), e.g. a StructureMap whose
+    // narrative was deliberately rendered by StructureMapTransformProvider - those keep their narrative.
+    if (packageInfo != null && stripPackageNarrative && r instanceof DomainResource domainResource
+      && domainResource.hasText()) {
+      domainResource.setText(null);
+    }
     synchronized (lock) {
       definitionsChanged();
       if (packageInfo != null) {
@@ -3765,6 +3781,21 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
     return res;
   }
+
+  // matchbox patch, see stripPackageNarrative
+  public boolean isStripPackageNarrative() {
+    return stripPackageNarrative;
+  }
+
+  /**
+   * Whether the narrative of conformance resources loaded from a package is dropped instead of being kept in
+   * memory. Only affects resources cached after this call. Defaults to true, unless the system property
+   * {@code matchbox.retainPackageNarrative} is set.
+   */
+  public void setStripPackageNarrative(boolean stripPackageNarrative) {
+    this.stripPackageNarrative = stripPackageNarrative;
+  }
+  // END matchbox patch
 
   public void setLocale(Locale locale) {
     // matchbox patch https://github.com/ahdis/matchbox/issues/425


### PR DESCRIPTION
Closes #566.

Conformance resources loaded from a package keep their narrative (`DomainResource.text`) in the validation context for the lifetime of the engine, but validation never reads it. On a bare R4 engine the parsed XHTML is the 3rd, 7th and 11th largest class by retained size, ahead of `ElementDefinition` at 15th.

### The change

31 added lines in `BaseWorkerContext`, no existing logic modified:

```java
if (packageInfo != null && stripPackageNarrative && r instanceof DomainResource domainResource
  && domainResource.hasText()) {
  domainResource.setText(null);
}
```

- `cacheResourceFromPackage()` is the single point every conformance resource passes through, so one insertion covers the classpath core package, the bundled terminology/extensions packages, and the IGs loaded through `IgLoaderFromJpaPackageCache`.
- The `packageInfo != null` guard keeps runtime-cached resources intact: `cacheResource(r)` delegates to `cacheResourceFromPackage(r, null)`, so the narrative that `StructureMapTransformProvider` deliberately renders for a StructureMap is preserved.
- On by default, revertable with `-Dmatchbox.retainPackageNarrative=true`, and the flag is propagated through `copy()` so derived engines inherit it.

This matches what HAPI already does when persisting package resources in `JpaPackageCache.addPackageToCache()` (`ResourceUtil.removeNarrative`, "in order to reduce the footprint ... keeping lots of them in memory"). The database therefore already stored narrative-free conformance resources while the in-memory contexts kept the full narrative from the package tarball; this makes the two consistent.

### Behaviour on the server, with the core engine shared

You asked specifically about this. Measured with the released Docker image, `igsPreloaded: myhealth.eu.fhir.laboratory#0.1.1`, so the core engine is built once and the validation engine is derived from it. Heap read from `/actuator/metrics/jvm.memory.used` after a forced GC:

| | heap used | container RSS |
|---|---|---|
| current | 2,427 MiB | 6.05 GiB |
| this PR | 1,206 MiB | 4.23 GiB |

Engine level, same IG (10 packages, 15,904 conformance resources), live heap after a forced GC:

| | current | this PR |
|---|---|---|
| core R4 engine, no IG | 1,263 MiB | 648 MiB |
| one engine + IG closure | 2,143 MiB | 922 MiB |
| two engines, same IG | 3,035 MiB | 1,208 MiB |

One consequence of the sharing worth stating explicitly: `CanonicalResourceManager.copy()` shares `CachedCanonicalResource` instances between the core engine and the engines derived from it, so the resource objects are the same objects. Stripping at load time is therefore global by construction, and the `retainPackageNarrative` flag is not meaningful per-engine. That is the intended behaviour here, but it does mean the flag has to be set at startup.

### Tests

- `matchbox-engine`: 96 tests, 0 failures (including `FhirMappingLanguageTests` and `CdaToFhirTransformTests`)
- `matchbox-server`: 46 tests, 0 failures (including `GazelleApiR4Test`, `TransformTest`, `MbInstalledStructureDefinitionIsCurrentTest`)

Validation output is unchanged in our runs (identical issue sets) and marginally faster: 341 ms cold / 91 ms warm against 368 / 92 before.

I have not run `matchbox-int-tests` locally; happy to do so if that is useful before merging.

### One behaviour change to weigh

`ConformancePackageResourceProvider.read()` returns the engine's copy for current-version resources, so `GET /StructureDefinition/{id}` on a current package no longer includes `text`. It already returned narrative-free resources for non-current versions through the database path, so this makes the API consistent, but it is a visible change and it is your call whether the default should be the other way round.
