### PR TITLE
Don't treat national core IGs as FHIR core packages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ Unreleased
 - Add the configuration property `matchbox.fhir.validation.analyzeErrorsWithLlm` (#561)
 - Add the configuration property `matchbox.fhir.mcp.requestAnalysisFromClient` (#561)
 - Allow to override `llmProvider` in the validation GUI
+- Fix national core IGs (`hl7.fhir.fr.core`, `hl7.fhir.us.core`, ...) failing to resolve because they were treated as FHIR core packages and looked up on the classpath (#568)
 
 2026/08/14 Release 4.1.13
 

--- a/matchbox-engine/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/matchbox-engine/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -348,7 +348,10 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       return new InputStreamWithSrc(stream, "http://fhir.org/", version);
     }
 
-    if (id.startsWith("hl7.fhir") && id.endsWith("core")) {
+    // matchbox-engine PATCH, the FHIR core packages are provided in the classpath.
+    // Note: this must not use a startsWith/endsWith test on the id, it would also capture the national core
+    // IGs (hl7.fhir.fr.core, hl7.fhir.us.core, hl7.fhir.be.core, ...), which are ordinary packages.
+    if (VersionUtilities.isCorePackage(id)) {
       ourLog.info("loading from classpath "+id);
       InputStream stream = getClass().getResourceAsStream("/"+id+".tgz");
       if (stream==null) {

--- a/matchbox-engine/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManagerTest.java
+++ b/matchbox-engine/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManagerTest.java
@@ -1,0 +1,62 @@
+package org.hl7.fhir.utilities.npm;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Matchbox serves the FHIR core packages from the classpath instead of going to a package server. These tests
+ * pin down which package identifiers that applies to.
+ */
+class FilesystemPackageCacheManagerTest {
+
+	/** The message of the exception raised when a package is expected on the classpath but is not there. */
+	private static final String CLASSPATH_FAILURE = "we don't want go to the package server";
+
+	private static FilesystemPackageCacheManager manager;
+
+	@BeforeAll
+	static void setUp() throws IOException {
+		manager = new FilesystemPackageCacheManager.Builder().withTestingCacheFolder().build();
+	}
+
+	@Test
+	void fhirCorePackagesAreServedFromTheClasspath() throws IOException {
+		for (final String id : List.of("hl7.fhir.r4.core", "hl7.fhir.r4b.core", "hl7.fhir.r5.core")) {
+			final var loaded = manager.loadFromPackageServer(id, "4.0.1");
+			assertNotNull(loaded, id + " should be served from the classpath");
+			assertNotNull(loaded.stream, id + " should provide a stream");
+			loaded.stream.close();
+		}
+	}
+
+	/**
+	 * National core IGs such as hl7.fhir.fr.core, hl7.fhir.us.core or hl7.fhir.be.core are ordinary packages:
+	 * they are not shipped in the matchbox-engine jar and must be resolved through the package server. They
+	 * used to be captured by a `startsWith("hl7.fhir") && endsWith("core")` test and failed to resolve.
+	 */
+	@Test
+	void nationalCoreIgsAreNotServedFromTheClasspath() {
+		for (final String id : List.of("hl7.fhir.fr.core", "hl7.fhir.us.core", "hl7.fhir.be.core")) {
+			String message = null;
+			try {
+				final var loaded = manager.loadFromPackageServer(id, "0.0.1-this-version-does-not-exist");
+				if (loaded != null && loaded.stream != null) {
+					loaded.stream.close();
+				}
+			} catch (final Exception e) {
+				message = String.valueOf(e.getMessage());
+			}
+			// Whether the package server can be reached or not is irrelevant here: what matters is that the
+			// package was looked for on the package server and not on the classpath.
+			assertFalse(message != null && message.contains(CLASSPATH_FAILURE),
+							"%s must be resolved through the package server, but was looked up on the classpath: %s"
+								.formatted(id, message));
+		}
+	}
+}


### PR DESCRIPTION
Closes #568.

`loadFromPackageServer()` serves the FHIR core packages from the classpath, where matchbox-engine ships them, instead of going to a package server. The test it used also captured the national core IGs:

```java
- if (id.startsWith("hl7.fhir") && id.endsWith("core")) {
+ if (VersionUtilities.isCorePackage(id)) {
```

`hl7.fhir.fr.core`, `hl7.fhir.us.core` and `hl7.fhir.be.core` are ordinary packages and are not in the jar, so resolving one failed with `Unable to find/resolve/read from classpath (we don't want go to the package server)`. We hit it with `hl7.fhir.fr.core#2.1.0`, a direct dependency of `ans.fhir.fr.tddui#2.0.0`.

`VersionUtilities.isCorePackage()` matches exactly the eight FHIR core package identifiers (`hl7.fhir.core`, `hl7.fhir.r2.core` ... `hl7.fhir.r6.core`), which is what the branch was meant to catch.

### Scope

The identifiers that legitimately take this branch are unaffected: the jar ships `hl7.fhir.r4.core.tgz`, `hl7.fhir.r4b.core.tgz` and `hl7.fhir.r5.core.tgz`, and ids such as `hl7.fhir.r2.core` matched the old test and match the new one, so they behave exactly as before. `hl7.cda.uv.core` never matched either test.

### Tests

Added `FilesystemPackageCacheManagerTest` with the two halves of the contract:

- `fhirCorePackagesAreServedFromTheClasspath` — r4 / r4b / r5 still resolve from the jar. Passes before and after the change, so it pins the behaviour that must not regress.
- `nationalCoreIgsAreNotServedFromTheClasspath` — fails on the current code with `hl7.fhir.fr.core must be resolved through the package server, but was looked up on the classpath`, passes with the fix.

The second test uses a version that cannot exist and only asserts that the failure is *not* the classpath one, so it does not depend on the package server being reachable and fails only if a national IG is captured by that branch again.

Full `matchbox-engine` suite: 98 tests, 0 failures, 2 pre-existing skips.
