### PR TITLE
Fix reading a conformance resource by its string id (#573)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+
+- Fix reading a conformance resource (StructureMap, StructureDefinition, ...) by the string id it was created with,
+  which failed with a 500 because the id was always parsed as a number; an unknown id now returns a 404 (#573)
+
 2026/08/31 Release 4.1.14
 
 - Try to parse the LLM providers' JSON error responses to provide more meaningful error messages (#531)

--- a/matchbox-server/src/main/java/ch/ahdis/matchbox/providers/ConformancePackageResourceProvider.java
+++ b/matchbox-server/src/main/java/ch/ahdis/matchbox/providers/ConformancePackageResourceProvider.java
@@ -192,10 +192,14 @@ public class ConformancePackageResourceProvider<R4 extends MetadataResource, R4B
 
 			final int offset = 0;
 			final int count = 1;
+			// resources loaded from the JPA package cache have a numeric id, resources added at runtime to the engine
+			// (see the create/update methods) have a string id, so we only query the package cache for numeric ids
 			Slice<NpmPackageVersionResourceEntity> outcome = null;
-			outcome = myPackageVersionResourceDao.findByResourceTypeById(PageRequest.of(offset, count),
-																							 resourceType,
-																							 theId.getIdPartAsLong());
+			if (theId.isIdPartValidLong()) {
+				outcome = myPackageVersionResourceDao.findByResourceTypeById(PageRequest.of(offset, count),
+																								 resourceType,
+																								 theId.getIdPartAsLong());
+			}
 			if (outcome != null && outcome.getSize() == 1) {
 				NpmPackageVersionResourceEntity res = outcome.toList().getFirst();
 				IBaseResource resource = (IBaseResource) loadPackageEntityAdjustId(outcome.toList().getFirst());
@@ -231,7 +235,11 @@ public class ConformancePackageResourceProvider<R4 extends MetadataResource, R4B
 				}
 				return loadPackageEntityAdjustId(outcome.toList().getFirst());
 			} else {
-				return matchboxEngineSupport.getCachedResource(resourceType, theId.getIdPart());
+				final IBaseResource cached = matchboxEngineSupport.getCachedResource(resourceType, theId.getIdPart());
+				if (cached == null) {
+					throw new ResourceNotFoundException(theId);
+				}
+				return cached;
 			}
 		});
 	}

--- a/matchbox-server/src/test/java/ch/ahdis/matchbox/mapping/TransformTest.java
+++ b/matchbox-server/src/test/java/ch/ahdis/matchbox/mapping/TransformTest.java
@@ -134,6 +134,46 @@ public class TransformTest {
 			 </TRight>""", response.body());
 	}
 
+	/**
+	 * The POST of a StructureMap returns a resource with a string id (the last segment of the canonical URL). Reading
+	 * the resource back with that id must work, see <a href="https://github.com/ahdis/matchbox/issues/573">issue
+	 * 573</a>.
+	 */
+	@Test
+	void testReadStructureMapByStringId() throws Exception {
+		final var createMapRequest = HttpRequest.newBuilder(URI.create(TARGET_SERVER + "/fhir/StructureMap"))
+			.POST(HttpRequest.BodyPublishers.ofString(this.getContent("qr2patgender.map")))
+			.header("Content-Type", "text/fhir-mapping")
+			.header("Accept", "application/fhir+json")
+			.build();
+		final var createResponse = this.httpClient.send(createMapRequest, HttpResponse.BodyHandlers.ofString());
+		assertEquals(201, createResponse.statusCode());
+		assertTrue(createResponse.body().replace(" ", "").contains("\"id\":\"qr2patgender\""),
+					  "the created StructureMap should have the id 'qr2patgender': " + createResponse.body());
+
+		final var readRequest = HttpRequest.newBuilder(URI.create(TARGET_SERVER + "/fhir/StructureMap/qr2patgender"))
+			.GET()
+			.header("Accept", "application/fhir+json")
+			.build();
+		final var readResponse = this.httpClient.send(readRequest, HttpResponse.BodyHandlers.ofString());
+		assertEquals(200, readResponse.statusCode(), "reading the StructureMap by its id failed: " + readResponse.body());
+		assertTrue(readResponse.body().contains("http://ahdis.ch/matchbox/fml/qr2patgender"),
+					  "the read StructureMap should have the expected canonical URL: " + readResponse.body());
+	}
+
+	/**
+	 * Reading a StructureMap with an unknown (non-numeric) id shall return a 404, not a server error.
+	 */
+	@Test
+	void testReadStructureMapByUnknownStringId() throws Exception {
+		final var readRequest = HttpRequest.newBuilder(URI.create(TARGET_SERVER + "/fhir/StructureMap/thisMapDoesNotExist"))
+			.GET()
+			.header("Accept", "application/fhir+json")
+			.build();
+		final var readResponse = this.httpClient.send(readRequest, HttpResponse.BodyHandlers.ofString());
+		assertEquals(404, readResponse.statusCode(), "expected a 404: " + readResponse.body());
+	}
+
 	private String getContent(final String resourceName) throws IOException {
 		Resource resource = new ClassPathResource(resourceName);
 		File file = resource.getFile();


### PR DESCRIPTION
Fixes #573.

## Problem

`POST /fhir/StructureMap` (in `onlyOneEngine` mode) assigns a **string** id — the last segment of the canonical URL — and returns it in the response:

```json
{"resourceType":"StructureMap","id":"qr2patgender","url":"http://ahdis.ch/matchbox/fml/qr2patgender", ...}
```

But `GET /fhir/StructureMap/qr2patgender` answered with a 500:

```json
{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"processing",
 "diagnostics":"HAPI-0389: Failed to call access method: java.lang.NumberFormatException: For input string: \"qr2patgender\""}]}
```

`ConformancePackageResourceProvider.read()` mixes two id spaces: the JPA package cache (IGs loaded at boot, **numeric** ids) and the in-memory engine (resources POSTed at runtime, **string** ids). The string-id fallback (`matchboxEngineSupport.getCachedResource(...)`) was already there, but `theId.getIdPartAsLong()` was evaluated unconditionally before it and threw for any non-numeric id, making the fallback dead code.

## Fix

- Only query the package cache when the id is a valid long (`theId.isIdPartValidLong()`); otherwise fall through to the engine's string-id lookup.
- Throw `ResourceNotFoundException` when the fallback finds nothing, so an unknown id returns a 404 instead of `null` (which HAPI turned into a server error too).

## Tests

Two new tests in `TransformTest`, both of which failed before the fix (500 in each case):

- `testReadStructureMapByStringId` — POSTs `qr2patgender.map`, checks the response advertises `"id": "qr2patgender"`, then GETs that id and expects 200 with the canonical URL.
- `testReadStructureMapByUnknownStringId` — expects 404 for an unknown non-numeric id.

Full `matchbox-server` suite: 51 tests, 0 failures, 2 skipped (pre-existing `@Disabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)